### PR TITLE
add cudaPeekAtLastError as recommended to check for kernel errors

### DIFF
--- a/doc/PortingGuide.md
+++ b/doc/PortingGuide.md
@@ -33,22 +33,22 @@ Porting Step by Step
 - remove cuda specific includes on top of your header and source files
 - add include `cuda_to_cupla.hpp`
 
-**CUDA include**
-```C++
-#include <cuda_runtime.h>
-```
+  **CUDA include**
+  ```C++
+  #include <cuda_runtime.h>
+  ```
 
-**cupla include**
-```C++
-/* Do NOT include other headers that use CUDA runtime functions or variables
- * (see above) before this include.
- * The reason for this is that cupla renames CUDA host functions and device build in 
- * variables by using macros and macro functions.
- * Do NOT include other specific includes such as `<cuda.h>` (driver functions,
- * etc.).
- */
-#include <cuda_to_cupla.hpp>
-```
+  **cupla include**
+  ```C++
+  /* Do NOT include other headers that use CUDA runtime functions or variables
+   * (see above) before this include.
+   * The reason for this is that cupla renames CUDA host functions and device build in 
+   * variables by using macros and macro functions.
+   * Do NOT include other specific includes such as `<cuda.h>` (driver functions,
+   * etc.).
+   */
+  #include <cuda_to_cupla.hpp>
+  ```
 
 - transform kernels (`__global__` functions) to functors
 - the functor's `operator()` must be qualified as `const`
@@ -61,81 +61,109 @@ Porting Step by Step
 - add the qualifier `const` to each parameter which is not changed inside the
   kernel
 
-**CUDA kernel**
-```C++
-template< int blockSize >
-__global__ void fooKernel( int * ptr, float value )
-{
-    // ...
-}
-```
+  **CUDA kernel**
+  ```C++
+  template< int blockSize >
+  __global__ void fooKernel( int * ptr, float value )
+  {
+      // ...
+  }
+  ```
 
-**cupla kernel**
-```C++
-template< int blockSize >
-struct fooKernel
-{
-    template< typename T_Acc >
-    ALPAKA_FN_ACC
-    void operator()( T_Acc const & acc, int * const ptr, float const value) const
-    {
-        // ...
-    }
-};
-```
+  **cupla kernel**
+  ```C++
+  template< int blockSize >
+  struct fooKernel
+  {
+      template< typename T_Acc >
+      ALPAKA_FN_ACC
+      void operator()( T_Acc const & acc, int * const ptr, float const value) const
+      {
+          // ...
+      }
+  };
+  ```
 
 - The host side kernel call must be changed like this:
 
-**CUDA host side kernel call**
-```C++
-// ...
-dim3 gridSize(42,1,1);
-dim3 blockSize(256,1,1);
-// extern shared memory and stream is optional
-fooKernel< 16 ><<< gridSize, blockSize, 0, 0 >>>( ptr, 23 );
-```
+  **CUDA host side kernel call**
+  ```C++
+  // ...
+  dim3 gridSize(42,1,1);
+  dim3 blockSize(256,1,1);
+  // extern shared memory and stream is optional
+  fooKernel< 16 ><<< gridSize, blockSize, 0, 0 >>>( ptr, 23 );
+  ```
 
-**cupla host side kernel call**
-```C++
-// ...
-dim3 gridSize(42,1,1);
-dim3 blockSize(256,1,1);
-// extern shared memory and stream is optional
-CUPLA_KERNEL(fooKernel< 16 >)( gridSize, blockSize, 0, 0 )( ptr, 23 );
-```
+  **cupla host side kernel call**
+  ```C++
+  // ...
+  dim3 gridSize(42,1,1);
+  dim3 blockSize(256,1,1);
+  // extern shared memory and stream is optional
+  CUPLA_KERNEL(fooKernel< 16 >)( gridSize, blockSize, 0, 0 )( ptr, 23 );
+  ```
 
 - Static shared memory definitions
 
-**Cuda shared memory** (in kernel)
-```C++
-// ...
-__shared__ int foo;
-__shared__ int fooCArray[32];
-__shared__ int fooCArray2D[4][32];
+  **Cuda shared memory** (in kernel)
+  ```C++
+  // ...
+  __shared__ int foo;
+  __shared__ int fooCArray[32];
+  __shared__ int fooCArray2D[4][32];
+  
+  // extern shared memory (size was defined during the host side kernel call)
+  extern __shared__ float fooPtr[];
+  
+  int bar = fooCArray2D[ threadIdx.x ][ 0 ];
+  // ...
+  ```
+  
+  **cupla shared memory** (in kernel)
+  ```C++
+  // ...
+  sharedMem( foo, int );
+  /* It is not possible to use the C-notation of fixed size, shared memory
+   * C arrays in cupla. Instead use `cupla::Array<Type,size>`.
+   */
+  sharedMem( fooCArray, cupla::Array< int, 32 > );
+  sharedMem( fooCArray, cupla::Array< cupla::Array< int, 4 >, 32 > );
+  
+  // extern shared memory (size was defined during the host side kernel call)
+  sharedMemExtern( fooPtr, float * );
+  
+  int bar = fooCArray2D[ threadIdx.x ][ 0 ];
+  // ...
+  ```
 
-// extern shared memory (size was defined during the host side kernel call)
-extern __shared__ float fooPtr[];
+- use `ALPAKA_FN_ACC_CUDA_ONLY` in device function definitions and add an `acc` parameter. Note that to be exact the `acc` parameter is only necessary when `alpaka` functions like `blockIdx` or `atomicMax`, ... are used.
 
-int bar = fooCArray2D[ threadIdx.x ][ 0 ];
-// ...
-```
+  **CUDA**
 
-**cupla shared memory** (in kernel)
-```C++
-// ...
-sharedMem( foo, int );
-/* It is not possible to use the C-notation of fixed size, shared memory
- * C arrays in cupla. Instead use `cupla::Array<Type,size>`.
- */
-sharedMem( fooCArray, cupla::Array< int, 32 > );
-sharedMem( fooCArray, cupla::Array< cupla::Array< int, 4 >, 32 > );
+      template< typename T_Elem >
+      __device__ inline int deviceFunction( T_Elem x )
+      {
+          // ...
+      }
 
-// extern shared memory (size was defined during the host side kernel call)
-sharedMemExtern( fooPtr, float * );
+  **cupla**
 
-int bar = fooCArray2D[ threadIdx.x ][ 0 ];
-// ...
-```
+      template< typename T_Acc, typename T_Elem >
+      ALPAKA_FN_ACC_CUDA_ONLY inline int deviceFunction( T_Acc const & acc, T_Elem x )
+      {
+          // ...
+      }
+
+- add `acc` as first parameter to device function calls
+
+   **CUDA**
+
+       auto result = deviceFunction( x );
+
+   **cupla**
+
+       auto result = deviceFunction( acc, x );
 
 - Cupla code can be mixed with
   [**alpaka**](https://github.com/ComputationalRadiationPhysics/alpaka)

--- a/include/cupla/api/common.hpp
+++ b/include/cupla/api/common.hpp
@@ -38,3 +38,11 @@ cuplaGetErrorString(cuplaError_t);
  */
 cuplaError_t
 cuplaGetLastError();
+
+
+/** not supported
+ *
+ * @return always cuplaSuccess
+ */
+cuplaError_t
+cuplaPeekAtLastError();

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -86,5 +86,12 @@
 
 // atomic functions
 #define atomicAdd(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc, ppPointer, ppValue)
+#define atomicSub(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Sub>(acc, ppPointer, ppValue)
+#define atomicMin(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Min>(acc, ppPointer, ppValue)
+#define atomicMax(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Max>(acc, ppPointer, ppValue)
+#define atomicInc(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Inc>(acc, ppPointer, ppValue)
+#define atomicDec(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Dec>(acc, ppPointer, ppValue)
+#define atomicExch(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Exch>(acc, ppPointer, ppValue)
+#define atomicCAS(ppPointer,ppCompare,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Cas>(acc, ppPointer, ppCompare, ppValue)
 
 #define uint3 ::cupla::uint3

--- a/include/cupla/cudaToCupla/runtime.hpp
+++ b/include/cupla/cudaToCupla/runtime.hpp
@@ -59,6 +59,7 @@
 
 #define cudaDeviceSynchronize(...) cuplaDeviceSynchronize(__VA_ARGS__)
 
+#define cudaPeekAtLastError(...) cuplaPeekAtLastError(__VA_ARGS__)
 #define cudaGetLastError(...) cuplaGetLastError(__VA_ARGS__)
 
 #define cudaMemset(...) cuplaMemset(__VA_ARGS__)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -39,3 +39,9 @@ cuplaGetLastError()
 {
     return cuplaSuccess;
 }
+
+cuplaError_t
+cuplaPeekAtLastError()
+{
+    return cuplaSuccess;
+}


### PR DESCRIPTION
cudaPeekAtLastError as e.g. used [here](http://stackoverflow.com/questions/14038589/what-is-the-canonical-way-to-check-for-errors-using-the-cuda-runtime-api)