### PR TITLE
fiy that `nullptr` can not be freed

### DIFF
--- a/include/cupla/manager/Memory.hpp
+++ b/include/cupla/manager/Memory.hpp
@@ -103,6 +103,9 @@ namespace manager
         free( void * ptr)
         -> bool
         {
+            if( ptr == nullptr)
+                return true;
+
             auto& device = Device< DeviceType >::get();
             const auto deviceId = device.id();
 


### PR DESCRIPTION
handle free call for `nullptr`