### PR TITLE
Add CUDA APIs: PeekAtLastError, int_as_float, Atomics

### DIFF
--- a/doc/PortingGuide.md
+++ b/doc/PortingGuide.md
@@ -141,12 +141,12 @@ Porting Step by Step
   // ...
   ```
 
-- use `ALPAKA_FN_ACC_CUDA_ONLY` in device function definitions and add an `acc` parameter. Note that to be exact the `acc` parameter is only necessary when `alpaka` functions like `blockIdx` or `atomicMax`, ... are used.
+- use `ALPAKA_FN_ACC` in device function definitions and add an `acc` parameter. Note that to be exact the `acc` parameter is only necessary when `alpaka` functions like `blockIdx` or `atomicMax`, ... are used.
 
   **CUDA**
 
       template< typename T_Elem >
-      __device__ inline int deviceFunction( T_Elem x )
+      __device__ int deviceFunction( T_Elem x )
       {
           // ...
       }
@@ -154,7 +154,7 @@ Porting Step by Step
   **cupla**
 
       template< typename T_Acc, typename T_Elem >
-      ALPAKA_FN_ACC_CUDA_ONLY inline int deviceFunction( T_Acc const & acc, T_Elem x )
+      ALPAKA_FN_ACC int deviceFunction( T_Acc const & acc, T_Elem x )
       {
           // ...
       }

--- a/doc/PortingGuide.md
+++ b/doc/PortingGuide.md
@@ -33,22 +33,22 @@ Porting Step by Step
 - remove cuda specific includes on top of your header and source files
 - add include `cuda_to_cupla.hpp`
 
-**CUDA include**
-```C++
-#include <cuda_runtime.h>
-```
+  **CUDA include**
+  ```C++
+  #include <cuda_runtime.h>
+  ```
 
-**cupla include**
-```C++
-/* Do NOT include other headers that use CUDA runtime functions or variables
- * (see above) before this include.
- * The reason for this is that cupla renames CUDA host functions and device build in 
- * variables by using macros and macro functions.
- * Do NOT include other specific includes such as `<cuda.h>` (driver functions,
- * etc.).
- */
-#include <cuda_to_cupla.hpp>
-```
+  **cupla include**
+  ```C++
+  /* Do NOT include other headers that use CUDA runtime functions or variables
+   * (see above) before this include.
+   * The reason for this is that cupla renames CUDA host functions and device build in
+   * variables by using macros and macro functions.
+   * Do NOT include other specific includes such as `<cuda.h>` (driver functions,
+   * etc.).
+   */
+  #include <cuda_to_cupla.hpp>
+  ```
 
 - transform kernels (`__global__` functions) to functors
 - the functor's `operator()` must be qualified as `const`
@@ -61,85 +61,113 @@ Porting Step by Step
 - add the qualifier `const` to each parameter which is not changed inside the
   kernel
 
-**CUDA kernel**
-```C++
-template< int blockSize >
-__global__ void fooKernel( int * ptr, float value )
-{
-    // ...
-}
-```
+  **CUDA kernel**
+  ```C++
+  template< int blockSize >
+  __global__ void fooKernel( int * ptr, float value )
+  {
+      // ...
+  }
+  ```
 
-**cupla kernel**
-```C++
-template< int blockSize >
-struct fooKernel
-{
-    template< typename T_Acc >
-    ALPAKA_FN_ACC
-    void operator()( T_Acc const & acc, int * const ptr, float const value) const
-    {
-        // ...
-    }
-};
-```
+  **cupla kernel**
+  ```C++
+  template< int blockSize >
+  struct fooKernel
+  {
+      template< typename T_Acc >
+      ALPAKA_FN_ACC
+      void operator()( T_Acc const & acc, int * const ptr, float const value) const
+      {
+          // ...
+      }
+  };
+  ```
 
 - The host side kernel call must be changed like this:
 
-**CUDA host side kernel call**
-```C++
-// ...
-dim3 gridSize(42,1,1);
-dim3 blockSize(256,1,1);
-// extern shared memory and stream is optional
-fooKernel< 16 ><<< gridSize, blockSize, 0, 0 >>>( ptr, 23 );
-```
+  **CUDA host side kernel call**
+  ```C++
+  // ...
+  dim3 gridSize(42,1,1);
+  dim3 blockSize(256,1,1);
+  // extern shared memory and stream is optional
+  fooKernel< 16 ><<< gridSize, blockSize, 0, 0 >>>( ptr, 23 );
+  ```
 
-**cupla host side kernel call**
-```C++
-// ...
-dim3 gridSize(42,1,1);
-dim3 blockSize(256,1,1);
-// extern shared memory and stream is optional
-CUPLA_KERNEL(fooKernel< 16 >)( gridSize, blockSize, 0, 0 )( ptr, 23 );
-```
+  **cupla host side kernel call**
+  ```C++
+  // ...
+  dim3 gridSize(42,1,1);
+  dim3 blockSize(256,1,1);
+  // extern shared memory and stream is optional
+  CUPLA_KERNEL(fooKernel< 16 >)( gridSize, blockSize, 0, 0 )( ptr, 23 );
+  ```
 
 - Static shared memory definitions
 
-**Cuda shared memory** (in kernel)
-```C++
-// ...
-__shared__ int foo;
-__shared__ int fooCArray[32];
-__shared__ int fooCArray2D[4][32];
+  **Cuda shared memory** (in kernel)
+  ```C++
+  // ...
+  __shared__ int foo;
+  __shared__ int fooCArray[32];
+  __shared__ int fooCArray2D[4][32];
 
-// extern shared memory (size was defined during the host side kernel call)
-extern __shared__ float fooPtr[];
+  // extern shared memory (size was defined during the host side kernel call)
+  extern __shared__ float fooPtr[];
 
-int bar = fooCArray2D[ threadIdx.x ][ 0 ];
-// ...
-```
+  int bar = fooCArray2D[ threadIdx.x ][ 0 ];
+  // ...
+  ```
 
-**cupla shared memory** (in kernel)
-```C++
-// ...
-sharedMem( foo, int );
-/* It is not possible to use the C-notation of fixed size, shared memory
- * C arrays in cupla. Instead use `cupla::Array<Type,size>`.
- */
-sharedMem( fooCArray, cupla::Array< int, 32 > );
-sharedMem( fooCArray, cupla::Array< cupla::Array< int, 4 >, 32 > );
+  **cupla shared memory** (in kernel)
+  ```C++
+  // ...
+  sharedMem( foo, int );
+  /* It is not possible to use the C-notation of fixed size, shared memory
+   * C arrays in cupla. Instead use `cupla::Array<Type,size>`.
+   */
+  sharedMem( fooCArray, cupla::Array< int, 32 > );
+  sharedMem( fooCArray, cupla::Array< cupla::Array< int, 4 >, 32 > );
 
-/* extern shared memory (size was defined during the host side kernel call)
- *
- * The type of extern shared memory is always a plain pointer of the given type.
- * In this example the type of `fooPtr` is `float*`
- */
-sharedMemExtern( fooPtr, float );
+  /* extern shared memory (size was defined during the host side kernel call)
+   *
+   * The type of extern shared memory is always a plain pointer of the given type.
+   * In this example the type of `fooPtr` is `float*`
+   */
+  sharedMemExtern( fooPtr, float );
 
-int bar = fooCArray2D[ threadIdx.x ][ 0 ];
-// ...
-```
+  int bar = fooCArray2D[ threadIdx.x ][ 0 ];
+  // ...
+  ```
+
+- use `ALPAKA_FN_ACC_CUDA_ONLY` in device function definitions and add an `acc` parameter. Note that to be exact the `acc` parameter is only necessary when `alpaka` functions like `blockIdx` or `atomicMax`, ... are used.
+
+  **CUDA**
+
+      template< typename T_Elem >
+      __device__ inline int deviceFunction( T_Elem x )
+      {
+          // ...
+      }
+
+  **cupla**
+
+      template< typename T_Acc, typename T_Elem >
+      ALPAKA_FN_ACC_CUDA_ONLY inline int deviceFunction( T_Acc const & acc, T_Elem x )
+      {
+          // ...
+      }
+
+- add `acc` as first parameter to device function calls
+
+   **CUDA**
+
+       auto result = deviceFunction( x );
+
+   **cupla**
+
+       auto result = deviceFunction( acc, x );
 
 - Cupla code can be mixed with
   [**alpaka**](https://github.com/ComputationalRadiationPhysics/alpaka)

--- a/include/cupla/api/common.hpp
+++ b/include/cupla/api/common.hpp
@@ -38,3 +38,11 @@ cuplaGetErrorString(cuplaError_t);
  */
 cuplaError_t
 cuplaGetLastError();
+
+
+/** not supported
+ *
+ * @return always cuplaSuccess
+ */
+cuplaError_t
+cuplaPeekAtLastError();

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -41,8 +41,8 @@
 #define cudaPos cupla::Pos
 #define cudaArray cupla::cuplaArray;
 #define cudaPitchedPtr cupla::PitchedPtr
-#define cudaMemcpy3DParms cupla::Memcpy3DParms
 
+#define cudaMemcpy3DParms cupla::Memcpy3DParms
 
 #ifdef cudaEventDisableTiming
 #undef cudaEventDisableTiming
@@ -84,8 +84,6 @@
   static_cast<uint3>(                                                \
       ::alpaka::workdiv::getWorkDiv<::alpaka::Thread, ::alpaka::Elems>(acc))
 
-#define uint3 ::cupla::uint3
-
 // atomic functions
 #define atomicAdd(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc, ppPointer, ppValue)
 #define atomicSub(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Sub>(acc, ppPointer, ppValue)
@@ -95,6 +93,8 @@
 #define atomicDec(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Dec>(acc, ppPointer, ppValue)
 #define atomicExch(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Exch>(acc, ppPointer, ppValue)
 #define atomicCAS(ppPointer,ppCompare,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Cas>(acc, ppPointer, ppCompare, ppValue)
+
+#define uint3 ::cupla::uint3
 
 // recast functions
 /* defining these as inling functions will result in multiple declaration

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -109,10 +109,7 @@ namespace cupla {
     B A_as_B( A const & x )
     {
         static_assert( sizeof(A) == sizeof(B), "reinterpretation assumes data types of same size!" );
-        union ba { B b; A a; };
-        ba tmp;
-        tmp.a = x;
-        return tmp.b;
+        return reinterpret_cast< B const & >( x );
     }
 
 

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -97,14 +97,9 @@
 #define uint3 ::cupla::uint3
 
 // recast functions
-/* defining these as inling functions will result in multiple declaration
- * errors when using a CUDA accelerator with alpaka.
- * Note that there may be no spaces between the macro function name and
- * the argument parentheses. */
 namespace cupla {
 
-
-    template< class A, class B >
+    template< typename A, typename B >
     ALPAKA_FN_HOST_ACC
     B A_as_B( A const & x )
     {
@@ -112,9 +107,7 @@ namespace cupla {
         return reinterpret_cast< B const & >( x );
     }
 
-
 } // namespace cupla
-
 #ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
 #   define __int_as_float(...) cupla::A_as_B< int, float >( __VA_ARGS__ )
 #   define __float_as_int(...) cupla::A_as_B< float, int >( __VA_ARGS__ )

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -96,3 +96,30 @@
 #define atomicCAS(ppPointer,ppCompare,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Cas>(acc, ppPointer, ppCompare, ppValue)
 
 #define uint3 ::cupla::uint3
+
+// recast functions
+/* defining these as inling functions will result in multiple declaration
+ * errors when using a CUDA accelerator with alpaka.
+ * Note that there may be no spaces between the macro function name and
+ * the argument parentheses. */
+namespace cupla {
+
+    template< class A, class B >
+    ALPAKA_FN_HOST_ACC
+    B __A_as_B( A const & x )
+    {
+        static_assert( sizeof(A) == sizeof(B), "reinterpretation assumes data types of same size!" );
+        union ba { B b; A a; };
+        ba tmp;
+        tmp.a = x;
+        return tmp.b;
+    }
+
+} // namespace cupla
+
+#ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
+#   define __int_as_float        (cupla::__A_as_B< int      , float     >)
+#   define __float_as_int        (cupla::__A_as_B< float    , int       >)
+#   define __longlong_as_double  (cupla::__A_as_B< long long, double    >)
+#   define __double_as_longlong  (cupla::__A_as_B< double   , long long >)
+#endif

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -38,7 +38,11 @@
 
 #define dim3 cupla::dim3
 #define cudaExtent cupla::Extent
+#define cudaPos cupla::Pos
+#define cudaArray cupla::cuplaArray;
 #define cudaPitchedPtr cupla::PitchedPtr
+#define cudaMemcpy3DParms cupla::Memcpy3DParms
+
 
 #ifdef cudaEventDisableTiming
 #undef cudaEventDisableTiming
@@ -53,7 +57,7 @@
       ::alpaka::block::shared::st::allocVar<__VA_ARGS__, __COUNTER__>(acc)
 
 #define sharedMemExtern(ppName, ...)                                           \
-    __VA_ARGS__ *ppName =                                                      \
+    __VA_ARGS__* ppName =                                                      \
         ::alpaka::block::shared::dyn::getMem<__VA_ARGS__>(acc)
 
 #define cudaMemcpyKind cuplaMemcpyKind
@@ -64,21 +68,23 @@
 
 // index renaming
 #define blockIdx                                                               \
-  static_cast<cupla::uint3>(                                                \
+  static_cast<uint3>(                                                \
       ::alpaka::idx::getIdx<::alpaka::Grid, ::alpaka::Blocks>(acc))
 #define threadIdx                                                              \
-  static_cast<cupla::uint3>(                                                \
+  static_cast<uint3>(                                                \
       ::alpaka::idx::getIdx<::alpaka::Block, ::alpaka::Threads>(acc))
 
 #define gridDim                                                                \
-  static_cast<cupla::uint3>(                                                \
+  static_cast<uint3>(                                                \
       ::alpaka::workdiv::getWorkDiv<::alpaka::Grid, ::alpaka::Blocks>(acc))
 #define blockDim                                                               \
-  static_cast<cupla::uint3>(                                                \
+  static_cast<uint3>(                                                \
       ::alpaka::workdiv::getWorkDiv<::alpaka::Block, ::alpaka::Threads>(acc))
 #define elemDim                                                               \
-  static_cast<cupla::uint3>(                                                \
+  static_cast<uint3>(                                                \
       ::alpaka::workdiv::getWorkDiv<::alpaka::Thread, ::alpaka::Elems>(acc))
+
+#define uint3 ::cupla::uint3
 
 // atomic functions
 #define atomicAdd(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc, ppPointer, ppValue)
@@ -98,10 +104,9 @@
 namespace cupla {
 
 
-    /* no matter how ALPAKA_FN_HOST_ACC is defined, we want to inline this */
     template< class A, class B >
-    ALPAKA_FN_NO_INLINE_HOST_ACC inline
-    B __A_as_B( A const & x )
+    ALPAKA_FN_HOST_ACC
+    B A_as_B( A const & x )
     {
         static_assert( sizeof(A) == sizeof(B), "reinterpretation assumes data types of same size!" );
         union ba { B b; A a; };
@@ -114,8 +119,8 @@ namespace cupla {
 } // namespace cupla
 
 #ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
-#   define __int_as_float( cupla::__A_as_B< int, float > )
-#   define __float_as_int( cupla::__A_as_B< float, int > )
-#   define __longlong_as_double( cupla::__A_as_B< long long, double > )
-#   define __double_as_longlong( cupla::__A_as_B< double, long long > )
+#   define __int_as_float(...) cupla::A_as_B< int, float >( __VA_ARGS__ )
+#   define __float_as_int(...) cupla::A_as_B< float, int >( __VA_ARGS__ )
+#   define __longlong_as_double(...) cupla::A_as_B< long long, double >( __VA_ARGS__ )
+#   define __double_as_longlong(...) cupla::A_as_B< double, long long >( __VA_ARGS__ )
 #endif

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -87,5 +87,12 @@
 // atomic functions
 #define atomicAdd(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc, ppPointer, ppValue)
 #define atomicExch(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Exch>(acc, ppPointer, ppValue)
+#define atomicSub(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Sub>(acc, ppPointer, ppValue)
+#define atomicMin(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Min>(acc, ppPointer, ppValue)
+#define atomicMax(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Max>(acc, ppPointer, ppValue)
+#define atomicInc(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Inc>(acc, ppPointer, ppValue)
+#define atomicDec(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Dec>(acc, ppPointer, ppValue)
+#define atomicExch(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Exch>(acc, ppPointer, ppValue)
+#define atomicCAS(ppPointer,ppCompare,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Cas>(acc, ppPointer, ppCompare, ppValue)
 
 #define uint3 ::cupla::uint3

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2015-2016 Rene Widera
+ * Copyright 2015-2016 Rene Widera, Maximilian Knespel
  *
  * This file is part of cupla.
  *
@@ -38,11 +38,7 @@
 
 #define dim3 cupla::dim3
 #define cudaExtent cupla::Extent
-#define cudaPos cupla::Pos
-#define cudaArray cupla::cuplaArray;
 #define cudaPitchedPtr cupla::PitchedPtr
-
-#define cudaMemcpy3DParms cupla::Memcpy3DParms
 
 #ifdef cudaEventDisableTiming
 #undef cudaEventDisableTiming
@@ -57,7 +53,7 @@
       ::alpaka::block::shared::st::allocVar<__VA_ARGS__, __COUNTER__>(acc)
 
 #define sharedMemExtern(ppName, ...)                                           \
-    __VA_ARGS__* ppName =                                                      \
+    __VA_ARGS__ *ppName =                                                      \
         ::alpaka::block::shared::dyn::getMem<__VA_ARGS__>(acc)
 
 #define cudaMemcpyKind cuplaMemcpyKind
@@ -68,25 +64,24 @@
 
 // index renaming
 #define blockIdx                                                               \
-  static_cast<uint3>(                                                \
+  static_cast<cupla::uint3>(                                                \
       ::alpaka::idx::getIdx<::alpaka::Grid, ::alpaka::Blocks>(acc))
 #define threadIdx                                                              \
-  static_cast<uint3>(                                                \
+  static_cast<cupla::uint3>(                                                \
       ::alpaka::idx::getIdx<::alpaka::Block, ::alpaka::Threads>(acc))
 
 #define gridDim                                                                \
-  static_cast<uint3>(                                                \
+  static_cast<cupla::uint3>(                                                \
       ::alpaka::workdiv::getWorkDiv<::alpaka::Grid, ::alpaka::Blocks>(acc))
 #define blockDim                                                               \
-  static_cast<uint3>(                                                \
+  static_cast<cupla::uint3>(                                                \
       ::alpaka::workdiv::getWorkDiv<::alpaka::Block, ::alpaka::Threads>(acc))
 #define elemDim                                                               \
-  static_cast<uint3>(                                                \
+  static_cast<cupla::uint3>(                                                \
       ::alpaka::workdiv::getWorkDiv<::alpaka::Thread, ::alpaka::Elems>(acc))
 
 // atomic functions
 #define atomicAdd(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Add>(acc, ppPointer, ppValue)
-#define atomicExch(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Exch>(acc, ppPointer, ppValue)
 #define atomicSub(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Sub>(acc, ppPointer, ppValue)
 #define atomicMin(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Min>(acc, ppPointer, ppValue)
 #define atomicMax(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Max>(acc, ppPointer, ppValue)
@@ -95,8 +90,6 @@
 #define atomicExch(ppPointer,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Exch>(acc, ppPointer, ppValue)
 #define atomicCAS(ppPointer,ppCompare,ppValue) ::alpaka::atomic::atomicOp<::alpaka::atomic::op::Cas>(acc, ppPointer, ppCompare, ppValue)
 
-#define uint3 ::cupla::uint3
-
 // recast functions
 /* defining these as inling functions will result in multiple declaration
  * errors when using a CUDA accelerator with alpaka.
@@ -104,8 +97,10 @@
  * the argument parentheses. */
 namespace cupla {
 
+
+    /* no matter how ALPAKA_FN_HOST_ACC is defined, we want to inline this */
     template< class A, class B >
-    ALPAKA_FN_HOST_ACC
+    ALPAKA_FN_NO_INLINE_HOST_ACC inline
     B __A_as_B( A const & x )
     {
         static_assert( sizeof(A) == sizeof(B), "reinterpretation assumes data types of same size!" );
@@ -115,11 +110,12 @@ namespace cupla {
         return tmp.b;
     }
 
+
 } // namespace cupla
 
 #ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
-#   define __int_as_float        (cupla::__A_as_B< int      , float     >)
-#   define __float_as_int        (cupla::__A_as_B< float    , int       >)
-#   define __longlong_as_double  (cupla::__A_as_B< long long, double    >)
-#   define __double_as_longlong  (cupla::__A_as_B< double   , long long >)
+#   define __int_as_float( cupla::__A_as_B< int, float > )
+#   define __float_as_int( cupla::__A_as_B< float, int > )
+#   define __longlong_as_double( cupla::__A_as_B< long long, double > )
+#   define __double_as_longlong( cupla::__A_as_B< double, long long > )
 #endif

--- a/include/cupla/cudaToCupla/runtime.hpp
+++ b/include/cupla/cudaToCupla/runtime.hpp
@@ -59,6 +59,7 @@
 
 #define cudaDeviceSynchronize(...) cuplaDeviceSynchronize(__VA_ARGS__)
 
+#define cudaPeekAtLastError(...) cuplaPeekAtLastError(__VA_ARGS__)
 #define cudaGetLastError(...) cuplaGetLastError(__VA_ARGS__)
 
 #define cudaMemset(...) cuplaMemset(__VA_ARGS__)

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -39,3 +39,9 @@ cuplaGetLastError()
 {
     return cuplaSuccess;
 }
+
+cuplaError_t
+cuplaPeekAtLastError()
+{
+    return cuplaSuccess;
+}


### PR DESCRIPTION
### Implemented CUDA APIs
  - add [`cudaPeekAtLastError`](https://docs.nvidia.com/cuda/cuda-c-programming-guide/#error-checking)
  - add several atomics:
    - atomicSub
    - atomicMin
    - atomicMax
    - atomicInc
    - atomicDec
    - atomicExch
    - atomicCAS
  - add [`__float_as_int`](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__INTRINSIC__CAST.html#group__CUDA__MATH__INTRINSIC__CAST_1g781a84bf3b7efe84969c2dc9b0915fa1) function

### Documentation Change
  - proper code indentation inside `PortingGuide.md`, so that the code blocks appear indented and inside the list items