### PR TITLE
change cupla type nameings

### DIFF
--- a/include/cupla/api/memory.hpp
+++ b/include/cupla/api/memory.hpp
@@ -25,11 +25,10 @@
 #include <alpaka/alpaka.hpp>
 
 
-#include "cupla/datatypes/Array.hpp"
 #include "cupla/datatypes/dim3.hpp"
 #include "cupla/datatypes/uint.hpp"
-#include "cupla/datatypes/Extent.hpp"
-#include "cupla/datatypes/PitchedPtr.hpp"
+#include "cupla/c/datatypes/cuplaExtent.hpp"
+#include "cupla/c/datatypes/cuplaPitchedPtr.hpp"
 
 #include "cupla/types.hpp"
 #include "cupla_driver_types.hpp"
@@ -58,26 +57,26 @@ cuplaMallocPitch(
 
 cuplaError_t
 cuplaMalloc3D(
-    cupla::PitchedPtr * pitchedDevPtr,
-    cupla::Extent const extent
+    cuplaPitchedPtr * pitchedDevPtr,
+    cuplaExtent const extent
 );
 
 
-cupla::Extent
+cuplaExtent
 make_cuplaExtent(
     size_t const w,
     size_t const h,
     size_t const d
 );
 
-cupla::Pos
+cuplaPos
 make_cuplaPos(
     size_t const x,
     size_t const y,
     size_t const z
 );
 
-cupla::PitchedPtr
+cuplaPitchedPtr
 make_cuplaPitchedPtr(
     void * const d,
     size_t const p,
@@ -148,11 +147,11 @@ cuplaMemcpy2DAsync(
 
 cuplaError_t
 cuplaMemcpy3DAsync(
-    const cupla::Memcpy3DParms * const p,
+    const cuplaMemcpy3DParms * const p,
     cuplaStream_t stream = 0
 );
 
 cuplaError_t
 cuplaMemcpy3D(
-    const cupla::Memcpy3DParms * const p
+    const cuplaMemcpy3DParms * const p
 );

--- a/include/cupla/c/datatypes/cuplaArray.hpp
+++ b/include/cupla/c/datatypes/cuplaArray.hpp
@@ -23,32 +23,11 @@
 #pragma once
 
 #include "cupla/types.hpp"
-#include "cupla/datatypes/uint.hpp"
+#include "cupla/c/datatypes/cuplaPitchedPtr.hpp"
+#include "cupla/c/datatypes/cuplaPos.hpp"
+#include "cupla/c/datatypes/cuplaExtent.hpp"
 
-namespace cupla
+
+struct cuplaArray
 {
-
-    struct PitchedPtr
-    {
-        MemSizeType pitch, xsize, ysize;
-        void * ptr;
-
-        ALPAKA_FN_HOST_ACC
-        PitchedPtr() = default;
-
-        ALPAKA_FN_HOST_ACC
-        PitchedPtr(
-            void * const d,
-            MemSizeType const p,
-            MemSizeType const xsz,
-            MemSizeType const ysz
-        ) :
-            ptr( d ),
-            pitch( p ),
-            xsize( xsz ),
-            ysize( ysz )
-        {}
-
-    };
-
-} //namespace cupla
+};

--- a/include/cupla/c/datatypes/cuplaExtent.hpp
+++ b/include/cupla/c/datatypes/cuplaExtent.hpp
@@ -24,62 +24,58 @@
 
 #include "cupla/types.hpp"
 
-namespace cupla
-{
+struct cuplaExtent{
+    cupla::MemSizeType width, height, depth;
 
-    struct Pos{
-        size_t x, y, z;
+    ALPAKA_FN_HOST_ACC
+    cuplaExtent() = default;
 
-        ALPAKA_FN_HOST_ACC
-        Pos() = default;
+    ALPAKA_FN_HOST_ACC
+    cuplaExtent(
+        cupla::MemSizeType const w,
+        cupla::MemSizeType const h,
+        cupla::MemSizeType const d
+    ) :
+        width( w ),
+        height( h ),
+        depth( d )
+    {}
 
-        ALPAKA_FN_HOST_ACC
-        Pos(
-            size_t const x_in,
-            size_t const y_in,
-            size_t const z_in
-        ) :
-            x( x_in ),
-            y( y_in ),
-            z( z_in )
-        {}
-
-        template<
-          typename TDim,
-          typename TSize,
-          typename = typename std::enable_if<
-              (TDim::value == 3u)
-          >::type
-        >
-        ALPAKA_FN_HOST_ACC
-        Pos(
-            ::alpaka::Vec<
-                TDim,
-                TSize
-            > const &vec
-        )
-        {
-            for( uint32_t i(0); i < 3u; ++i ) {
-                // alpaka vectors are z,y,x.
-                ( &this->x )[ i ] = vec[ ( 3u - 1u ) - i ];
-            }
+    template<
+      typename TDim,
+      typename TSize,
+      typename = typename std::enable_if<
+          (TDim::value == 3u)
+      >::type
+    >
+    ALPAKA_FN_HOST_ACC
+    cuplaExtent(
+        ::alpaka::Vec<
+            TDim,
+            TSize
+        > const &vec
+    )
+    {
+        for( uint32_t i(0); i < 3u; ++i ) {
+            // alpaka vectors are z,y,x.
+            ( &this->width )[ i ] = vec[ ( 3u - 1u ) - i ];
         }
+    }
 
-        ALPAKA_FN_HOST_ACC
-        operator ::alpaka::Vec<
+    ALPAKA_FN_HOST_ACC
+    operator ::alpaka::Vec<
+        cupla::AlpakaDim< 3u >,
+        cupla::MemSizeType
+    >(void) const
+    {
+        ::alpaka::Vec<
             cupla::AlpakaDim< 3u >,
-            MemSizeType
-        >(void) const
-        {
-            ::alpaka::Vec<
-                cupla::AlpakaDim< 3u >,
-                MemSizeType
-            > vec( x, y, z );
-            return vec;
-        }
-    };
+            cupla::MemSizeType
+        > vec( depth, height, width );
+        return vec;
+    }
+};
 
-} //namespace cupla
 
 
 namespace alpaka
@@ -92,7 +88,7 @@ namespace traits
     //! dimension get trait specialization
     template<>
     struct DimType<
-        cupla::Pos
+        cuplaExtent
     >{
       using type = ::alpaka::dim::DimInt<3u>;
     };
@@ -108,7 +104,7 @@ namespace traits
     //! element type trait specialization
     template<>
     struct ElemType<
-        cupla::Pos
+        cuplaExtent
     >{
         using type = cupla::MemSizeType;
     };
@@ -127,7 +123,7 @@ namespace traits
     >
     struct GetExtent<
         T_Idx,
-        cupla::Pos,
+        cuplaExtent,
         typename std::enable_if<
             (3u > T_Idx::value)
         >::type
@@ -135,21 +131,21 @@ namespace traits
 
         ALPAKA_FN_HOST_ACC
         static auto
-        getExtent( cupla::Pos const & extents )
+        getExtent( cuplaExtent const & extents )
         -> cupla::MemSizeType {
-        return (&extents.x)[(3u - 1u) - T_Idx::value];
+        return (&extents.width)[(3u - 1u) - T_Idx::value];
       }
     };
 
     //! extent set trait specialization
     template<
         typename T_Idx,
-        typename T_Pos
+        typename T_Extent
     >
     struct SetExtent<
         T_Idx,
-        cupla::Pos,
-        T_Pos,
+        cuplaExtent,
+        T_Extent,
         typename std::enable_if<
             (3u > T_Idx::value)
         >::type
@@ -157,12 +153,12 @@ namespace traits
         ALPAKA_FN_HOST_ACC
         static auto
         setExtent(
-            cupla::Pos &extents,
-            T_Pos const &extent
+            cuplaExtent &extents,
+            T_Extent const &extent
         )
         -> void
         {
-            (&extents.x)[(3u - 1u) - T_Idx::value] = extent;
+            (&extents.width)[(3u - 1u) - T_Idx::value] = extent;
         }
     };
 } // namespace traits
@@ -179,16 +175,16 @@ namespace traits
     >
     struct GetOffset<
         T_Idx,
-        cupla::Pos,
+        cuplaExtent,
         typename std::enable_if<
             (3u > T_Idx::value)
         >::type
     >{
         ALPAKA_FN_HOST_ACC
         static auto
-        getOffset( cupla::Pos const & offsets )
+        getOffset( cuplaExtent const & offsets )
         -> cupla::MemSizeType{
-            return (&offsets.x)[(3u - 1u) - T_Idx::value];
+            return (&offsets.width)[(3u - 1u) - T_Idx::value];
         }
     };
 
@@ -200,7 +196,7 @@ namespace traits
     >
     struct SetOffset<
         T_Idx,
-        cupla::Pos,
+        cuplaExtent,
         T_Offset,
         typename std::enable_if<
             (3u > T_Idx::value)
@@ -209,7 +205,7 @@ namespace traits
         ALPAKA_FN_HOST_ACC
         static auto
         setOffset(
-            cupla::Pos &offsets,
+            cuplaExtent &offsets,
             T_Offset const &offset
         )
         -> void {
@@ -227,7 +223,7 @@ namespace traits
     //! size type trait specialization.
     template<>
     struct SizeType<
-        cupla::Pos
+        cuplaExtent
     >{
         using type = cupla::MemSizeType;
     };

--- a/include/cupla/c/datatypes/cuplaMemcpy3DParms.hpp
+++ b/include/cupla/c/datatypes/cuplaMemcpy3DParms.hpp
@@ -22,29 +22,24 @@
 
 #pragma once
 
-#include <alpaka/alpaka.hpp>
-
-#include "cupla/kernel.hpp"
-
-#include "cupla/c/datatypes/cuplaArray.hpp"
-#include "cupla/datatypes/dim3.hpp"
-#include "cupla/datatypes/uint.hpp"
-#include "cupla/c/datatypes/cuplaExtent.hpp"
-#include "cupla/c/datatypes/cuplaPos.hpp"
-#include "cupla/c/datatypes/cuplaMemcpy3DParms.hpp"
-#include "cupla/c/datatypes/cuplaPitchedPtr.hpp"
-
 #include "cupla/types.hpp"
-#include "cupla_driver_types.hpp"
+#include "cupla/c/datatypes/cuplaArray.hpp"
+#include "cupla/c/datatypes/cuplaPitchedPtr.hpp"
+#include "cupla/c/datatypes/cuplaPos.hpp"
+#include "cupla/c/datatypes/cuplaExtent.hpp"
 
-#include "cupla/api/common.hpp"
-#include "cupla/api/device.hpp"
-#include "cupla/api/stream.hpp"
-#include "cupla/api/event.hpp"
-#include "cupla/api/memory.hpp"
-#include "cupla/manager/Driver.hpp"
 
-namespace cupla
+struct cuplaMemcpy3DParms
 {
-    const auto driver = manager::Driver::get();
-}
+    cuplaArray* dstArray;
+    cuplaPos dstPos;
+    cuplaPitchedPtr dstPtr;
+    cuplaExtent extent;
+    cuplaMemcpyKind kind;
+    cuplaArray * srcArray;
+    cuplaPos srcPos;
+    cuplaPitchedPtr srcPtr;
+
+    ALPAKA_FN_HOST_ACC
+    cuplaMemcpy3DParms() = default;
+};

--- a/include/cupla/c/datatypes/cuplaPitchedPtr.hpp
+++ b/include/cupla/c/datatypes/cuplaPitchedPtr.hpp
@@ -23,30 +23,28 @@
 #pragma once
 
 #include "cupla/types.hpp"
-#include "cupla/datatypes/PitchedPtr.hpp"
-#include "cupla/datatypes/Pos.hpp"
-#include "cupla/datatypes/Extent.hpp"
+#include "cupla/datatypes/uint.hpp"
 
-namespace cupla
+
+struct cuplaPitchedPtr
 {
+    cupla::MemSizeType pitch, xsize, ysize;
+    void * ptr;
 
-    struct cuplaArray
-    {
-    };
+    ALPAKA_FN_HOST_ACC
+    cuplaPitchedPtr() = default;
 
-    struct Memcpy3DParms
-    {
-        cuplaArray* dstArray;
-        Pos dstPos;
-        PitchedPtr dstPtr;
-        Extent extent;
-        cuplaMemcpyKind kind;
-        cuplaArray * srcArray;
-        Pos srcPos;
-        PitchedPtr srcPtr;
+    ALPAKA_FN_HOST_ACC
+    cuplaPitchedPtr(
+        void * const d,
+        cupla::MemSizeType const p,
+        cupla::MemSizeType const xsz,
+        cupla::MemSizeType const ysz
+    ) :
+        ptr( d ),
+        pitch( p ),
+        xsize( xsz ),
+        ysize( ysz )
+    {}
 
-        ALPAKA_FN_HOST_ACC
-        Memcpy3DParms() = default;
-    };
-
-} //namespace cupla
+};

--- a/include/cupla/c/datatypes/cuplaPos.hpp
+++ b/include/cupla/c/datatypes/cuplaPos.hpp
@@ -24,62 +24,58 @@
 
 #include "cupla/types.hpp"
 
-namespace cupla
-{
+struct cuplaPos{
+    size_t x, y, z;
 
-    struct Extent{
-        MemSizeType width, height, depth;
+    ALPAKA_FN_HOST_ACC
+    cuplaPos() = default;
 
-        ALPAKA_FN_HOST_ACC
-        Extent() = default;
+    ALPAKA_FN_HOST_ACC
+    cuplaPos(
+        size_t const x_in,
+        size_t const y_in,
+        size_t const z_in
+    ) :
+        x( x_in ),
+        y( y_in ),
+        z( z_in )
+    {}
 
-        ALPAKA_FN_HOST_ACC
-        Extent(
-            MemSizeType const w,
-            MemSizeType const h,
-            MemSizeType const d
-        ) :
-            width( w ),
-            height( h ),
-            depth( d )
-        {}
-
-        template<
-          typename TDim,
-          typename TSize,
-          typename = typename std::enable_if<
-              (TDim::value == 3u)
-          >::type
-        >
-        ALPAKA_FN_HOST_ACC
-        Extent(
-            ::alpaka::Vec<
-                TDim,
-                TSize
-            > const &vec
-        )
-        {
-            for( uint32_t i(0); i < 3u; ++i ) {
-                // alpaka vectors are z,y,x.
-                ( &this->width )[ i ] = vec[ ( 3u - 1u ) - i ];
-            }
+    template<
+      typename TDim,
+      typename TSize,
+      typename = typename std::enable_if<
+          (TDim::value == 3u)
+      >::type
+    >
+    ALPAKA_FN_HOST_ACC
+    cuplaPos(
+        ::alpaka::Vec<
+            TDim,
+            TSize
+        > const &vec
+    )
+    {
+        for( uint32_t i(0); i < 3u; ++i ) {
+            // alpaka vectors are z,y,x.
+            ( &this->x )[ i ] = vec[ ( 3u - 1u ) - i ];
         }
+    }
 
-        ALPAKA_FN_HOST_ACC
-        operator ::alpaka::Vec<
+    ALPAKA_FN_HOST_ACC
+    operator ::alpaka::Vec<
+        cupla::AlpakaDim< 3u >,
+        cupla::MemSizeType
+    >(void) const
+    {
+        ::alpaka::Vec<
             cupla::AlpakaDim< 3u >,
-            MemSizeType
-        >(void) const
-        {
-            ::alpaka::Vec<
-                cupla::AlpakaDim< 3u >,
-                MemSizeType
-            > vec( depth, height, width );
-            return vec;
-        }
-    };
+            cupla::MemSizeType
+        > vec( x, y, z );
+        return vec;
+    }
+};
 
-} //namespace cupla
 
 
 namespace alpaka
@@ -92,7 +88,7 @@ namespace traits
     //! dimension get trait specialization
     template<>
     struct DimType<
-        cupla::Extent
+        cuplaPos
     >{
       using type = ::alpaka::dim::DimInt<3u>;
     };
@@ -108,7 +104,7 @@ namespace traits
     //! element type trait specialization
     template<>
     struct ElemType<
-        cupla::Extent
+        cuplaPos
     >{
         using type = cupla::MemSizeType;
     };
@@ -127,7 +123,7 @@ namespace traits
     >
     struct GetExtent<
         T_Idx,
-        cupla::Extent,
+        cuplaPos,
         typename std::enable_if<
             (3u > T_Idx::value)
         >::type
@@ -135,21 +131,21 @@ namespace traits
 
         ALPAKA_FN_HOST_ACC
         static auto
-        getExtent( cupla::Extent const & extents )
+        getExtent( cuplaPos const & extents )
         -> cupla::MemSizeType {
-        return (&extents.width)[(3u - 1u) - T_Idx::value];
+        return (&extents.x)[(3u - 1u) - T_Idx::value];
       }
     };
 
     //! extent set trait specialization
     template<
         typename T_Idx,
-        typename T_Extent
+        typename T_Pos
     >
     struct SetExtent<
         T_Idx,
-        cupla::Extent,
-        T_Extent,
+        cuplaPos,
+        T_Pos,
         typename std::enable_if<
             (3u > T_Idx::value)
         >::type
@@ -157,12 +153,12 @@ namespace traits
         ALPAKA_FN_HOST_ACC
         static auto
         setExtent(
-            cupla::Extent &extents,
-            T_Extent const &extent
+            cuplaPos &extents,
+            T_Pos const &extent
         )
         -> void
         {
-            (&extents.width)[(3u - 1u) - T_Idx::value] = extent;
+            (&extents.x)[(3u - 1u) - T_Idx::value] = extent;
         }
     };
 } // namespace traits
@@ -179,16 +175,16 @@ namespace traits
     >
     struct GetOffset<
         T_Idx,
-        cupla::Extent,
+        cuplaPos,
         typename std::enable_if<
             (3u > T_Idx::value)
         >::type
     >{
         ALPAKA_FN_HOST_ACC
         static auto
-        getOffset( cupla::Extent const & offsets )
+        getOffset( cuplaPos const & offsets )
         -> cupla::MemSizeType{
-            return (&offsets.width)[(3u - 1u) - T_Idx::value];
+            return (&offsets.x)[(3u - 1u) - T_Idx::value];
         }
     };
 
@@ -200,7 +196,7 @@ namespace traits
     >
     struct SetOffset<
         T_Idx,
-        cupla::Extent,
+        cuplaPos,
         T_Offset,
         typename std::enable_if<
             (3u > T_Idx::value)
@@ -209,7 +205,7 @@ namespace traits
         ALPAKA_FN_HOST_ACC
         static auto
         setOffset(
-            cupla::Extent &offsets,
+            cuplaPos &offsets,
             T_Offset const &offset
         )
         -> void {
@@ -227,7 +223,7 @@ namespace traits
     //! size type trait specialization.
     template<>
     struct SizeType<
-        cupla::Extent
+        cuplaPos
     >{
         using type = cupla::MemSizeType;
     };

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include "cupla/datatypes/Array.hpp"
+
 #define __syncthreads(...) ::alpaka::block::sync::syncBlockThreads(acc)
 
 #define cudaSuccess cuplaSuccess
@@ -37,12 +39,12 @@
 #define cudaStream_t cuplaStream_t
 
 #define dim3 cupla::dim3
-#define cudaExtent cupla::Extent
-#define cudaPos cupla::Pos
-#define cudaArray cupla::cuplaArray;
-#define cudaPitchedPtr cupla::PitchedPtr
+#define cudaExtent cuplaExtent
+#define cudaPos cuplaPos
+#define cudaArray cuplaArray;
+#define cudaPitchedPtr cuplaPitchedPtr
 
-#define cudaMemcpy3DParms cupla::Memcpy3DParms
+#define cudaMemcpy3DParms cuplaMemcpy3DParms
 
 #ifdef cudaEventDisableTiming
 #undef cudaEventDisableTiming

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -77,8 +77,8 @@ cuplaMallocPitch(
 
 cuplaError_t
 cuplaMalloc3D(
-    cupla::PitchedPtr * const pitchedDevPtr,
-    cupla::Extent const extent
+    cuplaPitchedPtr * const pitchedDevPtr,
+    cuplaExtent const extent
 )
 {
 
@@ -98,27 +98,27 @@ cuplaMalloc3D(
     return cuplaSuccess;
 }
 
-cupla::Extent
+cuplaExtent
 make_cuplaExtent(
     size_t const w,
     size_t const h,
     size_t const d
 )
 {
-    return cupla::Extent( w, h, d );
+    return cuplaExtent( w, h, d );
 }
 
-cupla::Pos
+cuplaPos
 make_cuplaPos(
     size_t const x,
     size_t const y,
     size_t const z
 )
 {
-    return cupla::Pos( x, y, z );
+    return cuplaPos( x, y, z );
 }
 
-cupla::PitchedPtr
+cuplaPitchedPtr
 make_cuplaPitchedPtr(
     void * const d,
     size_t const p,
@@ -126,7 +126,7 @@ make_cuplaPitchedPtr(
     size_t const ysz
 )
 {
-    return cupla::PitchedPtr( d, p, xsz, ysz );
+    return cuplaPitchedPtr( d, p, xsz, ysz );
 }
 
 cuplaError_t
@@ -674,7 +674,7 @@ cuplaMemcpy2D(
 
 cuplaError_t
 cuplaMemcpy3DAsync(
-    const cupla::Memcpy3DParms * const p,
+    const cuplaMemcpy3DParms * const p,
     cuplaStream_t stream
 )
 {
@@ -932,7 +932,7 @@ cuplaMemcpy3DAsync(
 
 cuplaError_t
 cuplaMemcpy3D(
-    const cupla::Memcpy3DParms * const p
+    const cuplaMemcpy3DParms * const p
 )
 {
     cuplaDeviceSynchronize();


### PR DESCRIPTION
- rename all `cuda*` types to `cupla*` and remove the cupla namespace
- move files to directory `c` that means tere are no namespaces in
- fix dependancies

This pull request is the first step to cleanup the naming:
- if CUDA use the prefix `cudaTYPE` for a type the corresponding cupla type is `cuplaTYPE`
- if cuda use no prefix for a type (e.g., TYPE)  the corresponding  cupla type is placed in the namespace `cupla::TYPE` 