### PR TITLE
add support for two accelerators

### DIFF
--- a/include/cupla/traits/IsThreadSeqAcc.hpp
+++ b/include/cupla/traits/IsThreadSeqAcc.hpp
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2016 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include "cupla/types.hpp"
+
+namespace cupla
+{
+namespace traits
+{
+
+    /** check if thread level is full sequential
+     *
+     * \return ::value true if no threads where used in the thread level
+     *                  else false
+     */
+    template< typename T_Acc >
+    struct IsThreadSeqAcc
+    {
+        static constexpr bool value = false;
+    };
+
+
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+    template<
+        typename T_KernelDim,
+        typename T_IndexType
+    >
+    struct IsThreadSeqAcc<
+        ::alpaka::acc::AccCpuOmp2Blocks<
+            T_KernelDim,
+            T_IndexType
+        >
+    >
+    {
+        static constexpr bool value = true;
+    };
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+    template<
+        typename T_KernelDim,
+        typename T_IndexType
+    >
+    struct IsThreadSeqAcc<
+        ::alpaka::acc::AccCpuSerial<
+            T_KernelDim,
+            T_IndexType
+        >
+    >
+    {
+        static constexpr bool value = true;
+    };
+#endif
+
+}  // namespace traits
+} // namespace cupla


### PR DESCRIPTION
- add trait `IsThreadSeqAcc`
- change internal methods to queue a kernel
- add `AccThreadSeq` accelerator

**more details:**

- if one accelerator is enabled `cupla::AccThreadSeq` is equal to `cupla::Acc`
- This pull request allow under special conditions to enable two accelerators.
  This double selection is only useful for porting CUDA code to cupla.
  conditions:
    - one accelerator must be work fully sequential in the thread level
    - the other must be support a arbitrary number of threads in the thread level
- `CUPLA_KERNEL_OPTI` use always `cupla::AccThreadSeq` as accelerator


