### PR TITLE
remove defines for math functions

### DIFF
--- a/include/cupla/cudaToCupla/runtime.hpp
+++ b/include/cupla/cudaToCupla/runtime.hpp
@@ -78,11 +78,13 @@
 
 #define make_cudaPitchedPtr(...) make_cuplaPitchedPtr(__VA_ARGS__)
 
-//math
+/** define math intrinsics
+ *
+ * to avoid negative performance impact intrinsic function redefinitions
+ * are disabled in CUDA
+ */
 #if !defined(__CUDA_ARCH__)
 #define __fdividef(a,b) ((a)/(b))
-#define fabsf(a) alpaka::math::abs(acc,a)
 #define __expf(a) alpaka::math::exp(acc,a)
 #define __logf(a) alpaka::math::log(acc,a)
-#define rsqrtf(a) alpaka::math::rsqrt(acc,a)
 #endif


### PR DESCRIPTION
- remove `fabsf()`
- remove `rsqrtf()`

The definition of math function with macros can create conflicts with other libraries.
If math functions are needed the native **alpaka** functions can be used.