### PR TITLE
Topic add executable

### DIFF
--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -1,0 +1,35 @@
+#
+# Copyright 2016 Rene Widera
+#
+# This file is part of cupla.
+#
+# cupla is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# cupla is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with cupla.
+# If not, see <http://www.gnu.org/licenses/>.
+#
+
+# same dependency as ALPAKA_ADD_EXECUTABLE
+cmake_minimum_required(VERSION 3.3.0)
+
+
+function(CUPLA_ADD_EXECUTABLE BinaryName)
+
+    include_directories(${cupla_INCLUDE_DIRS})
+    add_definitions(${cupla_DEFINITIONS})
+
+    alpaka_add_executable(
+        ${BinaryName}
+        ${ARGN}
+        ${cupla_SOURCE_FILES}
+    )
+endfunction()

--- a/cuplaConfig.cmake
+++ b/cuplaConfig.cmake
@@ -55,6 +55,7 @@ unset(_cupla_LINK_LIBRARIES_PUBLIC)
 unset(_cupla_FILES_HEADER)
 unset(_cupla_FILES_SOURCE)
 unset(_cupla_FILES_OTHER)
+unset(_cupla_ADD_EXECUTABLE_FILE)
 
 ################################################################################
 # Directory of this file.
@@ -63,6 +64,10 @@ set(_cupla_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 # Normalize the path (e.g. remove ../)
 get_filename_component(_cupla_ROOT_DIR "${_cupla_ROOT_DIR}" ABSOLUTE)
+
+# Add cupla_ADD_EXECUTABLE function.
+set(_cupla_ADD_EXECUTABLE_FILE "${_cupla_ROOT_DIR}/cmake/addExecutable.cmake")
+include("${_cupla_ADD_EXECUTABLE_FILE}")
 
 ################################################################################
 # Set found to true initially and set it on false if a required dependency is missing.
@@ -283,6 +288,7 @@ if(NOT _cupla_FOUND)
     unset(_cupla_FILES_SOURCE)
     unset(_cupla_FILES_OTHER)
     unset(_cupla_VERSION)
+    unset(_cupla_ADD_EXECUTABLE_FILE)
 else()
     # Make internal variables advanced options in the GUI.
     MARK_AS_ADVANCED(
@@ -298,7 +304,9 @@ else()
         _cupla_FILES_HEADER
         _cupla_FILES_SOURCE
         _cupla_FILES_OTHER
-        _cupla_VERSION)
+        _cupla_VERSION
+        _cupla_ADD_EXECUTABLE_FILE
+    )
 endif()
 
 ###############################################################################

--- a/example/CUDASamples/asyncAPI/CMakeLists.txt
+++ b/example/CUDASamples/asyncAPI/CMakeLists.txt
@@ -60,18 +60,15 @@ append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_
 
 set(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
 
-include_directories(
-    ${_INCLUDE_DIRECTORIES_PRIVATE}
-    ${cupla_INCLUDE_DIRS})
-add_definitions(
-    ${cupla_DEFINITIONS})
+include_directories(${_INCLUDE_DIRECTORIES_PRIVATE})
+
+
 # Always add all files to the target executable build call to add them to the build project.
-alpaka_add_executable(
+cupla_add_executable(
     "asyncAPI"
-    ${_FILES_SOURCE_CXX}
-    ${cupla_SOURCE_FILES})
+    ${_FILES_SOURCE_CXX})
 
 # Set the link libraries for this library (adds libs, include directories, defines and compile options).
 target_link_libraries(
     "asyncAPI"
-    PUBLIC ${_cupla_LINK_LIBRARIES_PUBLIC})
+    PUBLIC ${cupla_LIBRARIES})

--- a/example/CUDASamples/asyncAPI_tuned/CMakeLists.txt
+++ b/example/CUDASamples/asyncAPI_tuned/CMakeLists.txt
@@ -60,18 +60,14 @@ append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_
 
 set(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
 
-include_directories(
-    ${_INCLUDE_DIRECTORIES_PRIVATE}
-    ${cupla_INCLUDE_DIRS})
-add_definitions(
-    ${cupla_DEFINITIONS})
+include_directories(${_INCLUDE_DIRECTORIES_PRIVATE})
+
 # Always add all files to the target executable build call to add them to the build project.
-alpaka_add_executable(
+cupla_add_executable(
     "asyncAPI_tuned"
-    ${_FILES_SOURCE_CXX}
-    ${cupla_SOURCE_FILES})
+    ${_FILES_SOURCE_CXX})
 
 # Set the link libraries for this library (adds libs, include directories, defines and compile options).
 target_link_libraries(
     "asyncAPI_tuned"
-    PUBLIC ${_cupla_LINK_LIBRARIES_PUBLIC})
+    PUBLIC ${cupla_LIBRARIES})

--- a/example/CUDASamples/matrixMul/CMakeLists.txt
+++ b/example/CUDASamples/matrixMul/CMakeLists.txt
@@ -60,18 +60,14 @@ append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_
 
 set(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
 
-include_directories(
-    ${_INCLUDE_DIRECTORIES_PRIVATE}
-    ${cupla_INCLUDE_DIRS})
-add_definitions(
-    ${cupla_DEFINITIONS})
+include_directories(${_INCLUDE_DIRECTORIES_PRIVATE})
+
 # Always add all files to the target executable build call to add them to the build project.
-alpaka_add_executable(
+cupla_add_executable(
     "matrixMul"
-    ${_FILES_SOURCE_CXX}
-    ${cupla_SOURCE_FILES})
+    ${_FILES_SOURCE_CXX})
 
 # Set the link libraries for this library (adds libs, include directories, defines and compile options).
 target_link_libraries(
     "matrixMul"
-    PUBLIC ${_cupla_LINK_LIBRARIES_PUBLIC})
+    PUBLIC ${cupla_LIBRARIES})

--- a/example/CUDASamples/vectorAdd/CMakeLists.txt
+++ b/example/CUDASamples/vectorAdd/CMakeLists.txt
@@ -60,18 +60,14 @@ append_recursive_files_add_to_src_group("${_SOURCE_DIR}" "" "cpp" _FILES_SOURCE_
 
 set(_INCLUDE_DIRECTORIES_PRIVATE ${_INCLUDE_DIR})
 
-include_directories(
-    ${_INCLUDE_DIRECTORIES_PRIVATE}
-    ${cupla_INCLUDE_DIRS})
-add_definitions(
-    ${cupla_DEFINITIONS})
+include_directories(${_INCLUDE_DIRECTORIES_PRIVATE})
+
 # Always add all files to the target executable build call to add them to the build project.
-alpaka_add_executable(
+cupla_add_executable(
     "vectorAdd"
-    ${_FILES_SOURCE_CXX}
-    ${cupla_SOURCE_FILES})
+    ${_FILES_SOURCE_CXX})
 
 # Set the link libraries for this library (adds libs, include directories, defines and compile options).
 target_link_libraries(
     "vectorAdd"
-    PUBLIC ${_cupla_LINK_LIBRARIES_PUBLIC})
+    PUBLIC ${cupla_LIBRARIES})


### PR DESCRIPTION
- add `cupla_add_executable` to simplify the handling of cupla intern source files
- use `cupla_add_executable()` in all examples
- use `cupla_LIBRARIES` instead of cupla internal variable