### PR TITLE
conversion CUDA native dim3->cupla::uint3

### DIFF
--- a/include/cupla/datatypes/uint.hpp
+++ b/include/cupla/datatypes/uint.hpp
@@ -53,6 +53,17 @@ namespace cupla
             }
         }
 
+#if( ALPAKA_ACC_GPU_CUDA_ENABLED == 1 )
+        ALPAKA_FN_HOST_ACC
+        uint3(
+          ::uint3 const & vec
+        ){
+            for (uint32_t i(0); i < 3u; ++i) {
+                (&(this->x))[i] = (&(vec.x))[i];
+            }
+        }
+#endif
+
         ALPAKA_FN_HOST_ACC
         operator ::alpaka::vec::Vec<
             cupla::AlpakaDim< 3u >,


### PR DESCRIPTION
This specification helps during the porting phase from CUDA to cupla. It is possible to include the cupla header and remove cupla redefinition. In that case it is possible to call `threadIdx`, ... without the need of an alpaka accelerator.

```
#include <cuda_to_cupla.hpp>

#if( ALPAKA_ACC_GPU_CUDA_ENABLED == 1 )
#   undef blockIdx
#   undef __syncthreads
#   undef threadIdx
#   undef gridDim
#   undef blockDim
#   undef uint3
#   undef dim3
#endif
```