### PR TITLE
add advanced cmake var `cupla_ALPAKA_PROVIDER`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,6 +18,11 @@ Requirements
     - `git submodule init`
     - `git submodule update`
     - `export CUPLA_ROOT=$HOME/src/cupla`
+  - use cupla without the submodule alpaka: 
+    Set the advanced CMake variable `cupla_ALPAKA_PROVIDER` to `extern` and
+    set environment variable `ALPAKA_ROOT` or extend `CMAKE_PREFIX_PATH` with the
+    path to alpaka.
+      
 
 compile an example
 -----------------

--- a/cuplaConfig.cmake
+++ b/cuplaConfig.cmake
@@ -96,16 +96,34 @@ OPTION(ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLE "Enable the OpenMP 2.0 CPU block threa
 OPTION(ALPAKA_ACC_CPU_BT_OMP4_ENABLE "Enable the OpenMP 4.0 CPU block and block thread accelerator" OFF)
 OPTION(ALPAKA_ACC_GPU_CUDA_ENABLE "Enable the CUDA GPU accelerator" OFF)
 
-if("$ENV{ALPAKA_ROOT}" STREQUAL "")
+
+set(cupla_ALPAKA_PROVIDER "intern" CACHE STRING "Select which alpaka is used")
+set_property(CACHE cupla_ALPAKA_PROVIDER PROPERTY STRINGS "intern;extern")
+mark_as_advanced(cupla_ALPAKA_PROVIDER)
+
+if(${cupla_ALPAKA_PROVIDER} STREQUAL "intern")
     if(NOT EXISTS "${_cupla_ROOT_DIR}/alpaka/Findalpaka.cmake")
         # Init the sub molules
         execute_process (COMMAND git submodule init WORKING_DIRECTORY ${_cupla_ROOT_DIR})
         # Update the sub modules
         execute_process (COMMAND git submodule update WORKING_DIRECTORY ${_cupla_ROOT_DIR})
     endif()
-endif()
 
-find_package(alpaka HINTS $ENV{ALPAKA_ROOT} "${_cupla_ROOT_DIR}/alpaka")
+    find_package(alpaka 
+        PATHS "${_cupla_ROOT_DIR}/alpaka"
+        NO_DEFAULT_PATH 
+        NO_CMAKE_ENVIRONMENT_PATH 
+        NO_CMAKE_PATH
+        NO_SYSTEM_ENVIRONMENT_PATH
+        NO_CMAKE_PACKAGE_REGISTRY
+        NO_CMAKE_BUILDS_PATH
+        NO_CMAKE_SYSTEM_PATH
+        NO_CMAKE_SYSTEM_PACKAGE_REGISTRY
+        NO_CMAKE_FIND_ROOT_PATH   
+    )
+else()
+    find_package(alpaka HINTS $ENV{ALPAKA_ROOT})
+endif()
 
 if(NOT alpaka_FOUND)
     message(WARNING "Required cupla dependency alpaka could not be found!")


### PR DESCRIPTION
- allow the usage of an extern alpaka by setting `cupla_ALPAKA_PROVIDER`
- call `git submodule init` only if internal alpaka is used