### PR TITLE
fix warning: CUDA 9

### DIFF
--- a/include/cupla/c/datatypes/cuplaExtent.hpp
+++ b/include/cupla/c/datatypes/cuplaExtent.hpp
@@ -27,7 +27,6 @@
 struct cuplaExtent{
     cupla::MemSizeType width, height, depth;
 
-    ALPAKA_FN_HOST_ACC
     cuplaExtent() = default;
 
     ALPAKA_FN_HOST_ACC

--- a/include/cupla/c/datatypes/cuplaMemcpy3DParms.hpp
+++ b/include/cupla/c/datatypes/cuplaMemcpy3DParms.hpp
@@ -40,6 +40,5 @@ struct cuplaMemcpy3DParms
     cuplaPos srcPos;
     cuplaPitchedPtr srcPtr;
 
-    ALPAKA_FN_HOST_ACC
     cuplaMemcpy3DParms() = default;
 };

--- a/include/cupla/c/datatypes/cuplaPitchedPtr.hpp
+++ b/include/cupla/c/datatypes/cuplaPitchedPtr.hpp
@@ -31,7 +31,6 @@ struct cuplaPitchedPtr
     cupla::MemSizeType pitch, xsize, ysize;
     void * ptr;
 
-    ALPAKA_FN_HOST_ACC
     cuplaPitchedPtr() = default;
 
     ALPAKA_FN_HOST_ACC

--- a/include/cupla/c/datatypes/cuplaPos.hpp
+++ b/include/cupla/c/datatypes/cuplaPos.hpp
@@ -27,7 +27,6 @@
 struct cuplaPos{
     size_t x, y, z;
 
-    ALPAKA_FN_HOST_ACC
     cuplaPos() = default;
 
     ALPAKA_FN_HOST_ACC

--- a/include/cupla/datatypes/uint.hpp
+++ b/include/cupla/datatypes/uint.hpp
@@ -30,7 +30,6 @@ namespace cupla
     struct uint3{
         IdxType x, y, z;
 
-        ALPAKA_FN_HOST_ACC
         uint3() = default;
 
         template<


### PR DESCRIPTION
remove location prefix for default constructor

```
/home/widera/src/cupla/include/cupla/c/datatypes/cuplaPitchedPtr.hpp(34): warning: __host__ annotation on a defaulted function("cuplaPitchedPtr") is ignored
```