### PR TITLE
fix id generation for events and streams

### DIFF
--- a/include/cupla/manager/Event.hpp
+++ b/include/cupla/manager/Event.hpp
@@ -148,8 +148,9 @@ namespace detail
                     flags
                 )
             );
+
             cuplaEvent_t eventId = reinterpret_cast< cuplaEvent_t >(
-                m_mapVector[ device.id() ].size()
+                m_id++
             );
             m_mapVector[ device.id() ].insert(
                 std::make_pair( eventId, std::move( eventPtr ) )
@@ -213,6 +214,8 @@ namespace detail
             const auto deviceId = device.id();
 
             m_mapVector[ deviceId ].clear( );
+            // reset id to allow that this instance can be reused
+            m_id = 0u;
 
             // @todo: check if clear creates errors
             return true;
@@ -223,6 +226,9 @@ namespace detail
         Event() :  m_mapVector( Device< DeviceType >::get().count() )
         {
         }
+
+        //! unique if for the next stream
+        size_t m_id = 0u;
 
     };
 

--- a/include/cupla/manager/Stream.hpp
+++ b/include/cupla/manager/Stream.hpp
@@ -78,7 +78,7 @@ namespace manager
                 )
             );
             cuplaStream_t streamId = reinterpret_cast< cuplaStream_t >(
-                m_mapVector[ device.id() ].size()
+                m_id++
             );
             m_mapVector[ device.id() ].insert(
                 std::make_pair( streamId, std::move( streamPtr ) )
@@ -151,6 +151,8 @@ namespace manager
             const auto deviceId = device.id();
 
             m_mapVector[ deviceId ].clear( );
+            // reset id to allow that this instance can be reused
+            m_id = 0u;
 
             // @todo: check if clear creates errors
             return true;
@@ -160,6 +162,9 @@ namespace manager
         Stream() :  m_mapVector( Device< DeviceType >::get().count() )
         {
         }
+
+        //! unique if for the next stream
+        size_t m_id = 0u;
 
     };
 


### PR DESCRIPTION
The id for events and streams is not unique as soon as on element is deleted.

- add static id counter within the factory methods to create a unique id