### PR TITLE
Doxygen: Fix Headers

### DIFF
--- a/example/CUDASamples/matrixMul/src/matrixMul.cpp
+++ b/example/CUDASamples/matrixMul/src/matrixMul.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 1993-2014 NVIDIA Corporation.  All rights reserved.
+/* Copyright 1993-2014 NVIDIA Corporation.  All rights reserved.
  *
  * Please refer to the NVIDIA end user license agreement (EULA) associated
  * with this source code for terms and conditions that govern your use of
@@ -9,8 +8,7 @@
  *
  */
 
-/**
- * Matrix multiplication: C = A * B.
+/** @file Matrix multiplication: C = A * B.
  * Host code.
  *
  * This sample implements matrix multiplication as described in Chapter 3
@@ -38,7 +36,7 @@
  * Matrix multiplication (CUDA Kernel) on the device: C = A * B
  * wA is A's width and wB is B's width
  */
-template <int BLOCK_SIZE> 
+template <int BLOCK_SIZE>
 struct matrixMulCUDA
 {
 
@@ -75,7 +73,7 @@ void operator()(T_Acc const& acc,float *C, float *A, float *B, int wA, int wB) c
 
    sharedMem(As, cupla::Array<cupla::Array<float,BLOCK_SIZE>,BLOCK_SIZE>);
    sharedMem(Bs, cupla::Array<cupla::Array<float,BLOCK_SIZE>,BLOCK_SIZE>);
-    
+
     // Loop over all the sub-matrices of A and B
     // required to compute the block sub-matrix
     for (int a = aBegin, b = bBegin;

--- a/example/CUDASamples/vectorAdd/src/vectorAdd.cpp
+++ b/example/CUDASamples/vectorAdd/src/vectorAdd.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+/* Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
  *
  * Please refer to the NVIDIA end user license agreement (EULA) associated
  * with this source code for terms and conditions that govern your use of
@@ -9,8 +8,7 @@
  *
  */
 
-/**
- * Vector addition: C = A + B.
+/** @file Vector addition: C = A + B.
  *
  * This sample is a very basic sample that implements element by element
  * vector addition. It is the same as the sample illustrating Chapter 2

--- a/include/cuda_to_cupla.hpp
+++ b/include/cuda_to_cupla.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/api/common.hpp
+++ b/include/cupla/api/common.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/api/device.hpp
+++ b/include/cupla/api/device.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/api/event.hpp
+++ b/include/cupla/api/event.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/api/memory.hpp
+++ b/include/cupla/api/memory.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/api/stream.hpp
+++ b/include/cupla/api/stream.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/c/datatypes/cuplaArray.hpp
+++ b/include/cupla/c/datatypes/cuplaArray.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/c/datatypes/cuplaExtent.hpp
+++ b/include/cupla/c/datatypes/cuplaExtent.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/c/datatypes/cuplaMemcpy3DParms.hpp
+++ b/include/cupla/c/datatypes/cuplaMemcpy3DParms.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/c/datatypes/cuplaPitchedPtr.hpp
+++ b/include/cupla/c/datatypes/cuplaPitchedPtr.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/c/datatypes/cuplaPos.hpp
+++ b/include/cupla/c/datatypes/cuplaPos.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2016 Rene Widera, Maximilian Knespel
+/* Copyright 2015-2016 Rene Widera, Maximilian Knespel
  *
  * This file is part of cupla.
  *

--- a/include/cupla/cudaToCupla/runtime.hpp
+++ b/include/cupla/cudaToCupla/runtime.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2016 Rene Widera
+/* Copyright 2015-2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/datatypes/Array.hpp
+++ b/include/cupla/datatypes/Array.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2016 Rene Widera
+/* Copyright 2015-2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/datatypes/dim3.hpp
+++ b/include/cupla/datatypes/dim3.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2016 Rene Widera
+/* Copyright 2015-2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/datatypes/uint.hpp
+++ b/include/cupla/datatypes/uint.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2015-2016 Rene Widera
+/* Copyright 2015-2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/kernel.hpp
+++ b/include/cupla/kernel.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/manager/Device.hpp
+++ b/include/cupla/manager/Device.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/manager/Driver.hpp
+++ b/include/cupla/manager/Driver.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/manager/Event.hpp
+++ b/include/cupla/manager/Event.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/manager/Memory.hpp
+++ b/include/cupla/manager/Memory.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/manager/Stream.hpp
+++ b/include/cupla/manager/Stream.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/traits/IsThreadSeqAcc.hpp
+++ b/include/cupla/traits/IsThreadSeqAcc.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla/types.hpp
+++ b/include/cupla/types.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla_driver_types.hpp
+++ b/include/cupla_driver_types.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/include/cupla_runtime.hpp
+++ b/include/cupla_runtime.hpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/src/manager/Driver.cpp
+++ b/src/manager/Driver.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1,5 +1,4 @@
-/**
- * Copyright 2016 Rene Widera
+/* Copyright 2016 Rene Widera
  *
  * This file is part of cupla.
  *


### PR DESCRIPTION
Fix falsely placed doxygen comments in file headers which show up at unexpected places.
(e.g. sphinx)