### PR TITLE
fix `cuplaGetLastError`

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -38,9 +38,10 @@ cuplaGetLastError()
 {
 #if (ALPAKA_ACC_GPU_CUDA_ENABLED == 1)
     // reset the last cuda error
-    cudaGetLastError();
-#endif
+    return (cuplaError_t)cudaGetLastError();
+#else
     return cuplaSuccess;
+#endif
 }
 
 cuplaError_t


### PR DESCRIPTION
If CUDA is used and `cuplaGetLastError` is called the return code was not returned.