### PR TITLE
add implementation for `cuplaGetErrorString`

### DIFF
--- a/include/cupla_driver_types.hpp
+++ b/include/cupla_driver_types.hpp
@@ -62,8 +62,13 @@ using cuplaEvent_t = void*;
 /** error category for `cuplaError` */
 struct CuplaErrorCode : public std::error_category
 {
-    virtual const char *name() const noexcept override { return "cuplaError"; }
-    virtual std::string message(int ev) const override {
+    char const * name() const noexcept override { return "cuplaError"; }
+    std::string message(int ev) const override
+	{
+        return message_cstr( ev );
+    }
+	static char const * message_cstr(int ev)
+	{
         switch(ev)
         {
             case cuplaSuccess:

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -28,9 +28,9 @@
 
 
 const char *
-cuplaGetErrorString(cuplaError_t)
+cuplaGetErrorString(cuplaError_t e)
 {
-    return "cuplaGetErrorString is currently not supported\n";
+    return CuplaErrorCode::message_cstr(e);
 }
 
 cuplaError_t


### PR DESCRIPTION
The function `cuplaGetErrorString` was available but not implemented.

- refactor `CuplaErrorCode` to support `const char*` as return type
- implement `cuplaGetErrorString()`