### PR TITLE
add `cuplaStreamQuery()`

### DIFF
--- a/include/cupla/api/stream.hpp
+++ b/include/cupla/api/stream.hpp
@@ -46,3 +46,6 @@ cuplaStreamWaitEvent(
     cuplaEvent_t event,
     unsigned int flags
 );
+
+cuplaError_t
+cuplaStreamQuery( cuplaStream_t stream );

--- a/include/cupla/cudaToCupla/runtime.hpp
+++ b/include/cupla/cudaToCupla/runtime.hpp
@@ -44,6 +44,7 @@
 #define cudaStreamDestroy(...) cuplaStreamDestroy(__VA_ARGS__)
 #define cudaStreamSynchronize(...) cuplaStreamSynchronize(__VA_ARGS__)
 #define cudaStreamWaitEvent(...) cuplaStreamWaitEvent(__VA_ARGS__)
+#define cudaStreamQuery(...) cuplaStreamQuery(__VA_ARGS__)
 
 #define cudaEventRecord(...) cuplaEventRecord(__VA_ARGS__)
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -87,3 +87,17 @@ cuplaStreamWaitEvent(
     ::alpaka::wait::wait(streamObject,eventObject);
     return cuplaSuccess;
 }
+
+cuplaError_t
+cuplaStreamQuery( cuplaStream_t stream )
+{
+    auto& streamObject = cupla::manager::Stream<
+        cupla::AccDev,
+        cupla::AccStream
+    >::get().stream( stream );
+
+    if( alpaka::stream::empty( streamObject ) )
+        return cuplaSuccess;
+    else
+        return cuplaErrorNotReady;
+};


### PR DESCRIPTION
fix #82

- add function `cuplaStreamQuery`
- add renaming definition from `cudaStreamQuery` to `cuplaStreamQuery`

Signed-off-by: René Widera <r.widera@hzdr.de>