### PR TITLE
implement `cuplaPeekAtLastError()`

### DIFF
--- a/include/cupla/api/common.hpp
+++ b/include/cupla/api/common.hpp
@@ -39,9 +39,12 @@ cuplaError_t
 cuplaGetLastError();
 
 
-/** not supported
+/** returns the last error from a runtime call.
  *
- * @return always cuplaSuccess
+ * This call does not reset the error code.
+ * @warning If a non CUDA Alpaka backend is used this function will return always cuplaSuccess
+ *
+ * @return cuplaSuccess if there was no error else the corresponding error type
  */
 cuplaError_t
 cuplaPeekAtLastError();

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -47,5 +47,9 @@ cuplaGetLastError()
 cuplaError_t
 cuplaPeekAtLastError()
 {
+#if (ALPAKA_ACC_GPU_CUDA_ENABLED == 1)
+    return (cuplaError_t)cudaPeekAtLastError();
+#else
     return cuplaSuccess;
+#endif
 }


### PR DESCRIPTION
queried in #82

Implement `cuplaPeekAtLastError()` for the cuda backend.