### PR TITLE
CI: switch from clang 3.5 to 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ install:
       cd $CUDA_ROOT &&
       travis_retry wget http://developer.download.nvidia.com/compute/cuda/7.5/Prod/local_installers/cuda_7.5.18_linux.run &&
       chmod u+x *.run &&
-      ./cuda_7.5.18_linux.run --silent --verbose --toolkit --toolkitpath=$CUDA_ROOT &&
+      ./cuda_7.5.18_linux.run --override --silent --verbose --toolkit --toolkitpath=$CUDA_ROOT &&
       rm -rf cuda_7.5.18_linux.run $CUDA_ROOT/{samples,jre,doc,share} &&
       cd -;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-3.5
+      - llvm-toolchain-precise-4.0
     packages:
       - g++-4.9
-      - clang-3.5
+      - clang-4.0
 
 env:
   global:
@@ -46,9 +46,9 @@ before_install:
         export CC=gcc-4.9;
         unset CUDA_ROOT;
     elif [ "$COMPILER" == "clang" ]; then
-        echo "Using clang++-3.5 & sequential threads ...";
-        export CXX=clang++-3.5;
-        export CC=clang-3.5;
+        echo "Using clang++-4.0 & sequential threads ...";
+        export CXX=clang++-4.0;
+        export CC=clang-4.0;
         unset CUDA_ROOT;
     elif [ "$COMPILER" == "nvcc" ]; then
         echo "Using CUDA 7.5 ...";

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 sudo: false
+dist: xenial
 
 cache:
   apt: true
@@ -12,7 +13,6 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise-4.0
     packages:
       - g++-4.9
       - clang-4.0


### PR DESCRIPTION
For #89 the minimum clang version must be 4.0

- use clang 4.0 for CI tests