### PR TITLE
fix dynamic shared mem definition

### DIFF
--- a/include/cupla/kernel.hpp
+++ b/include/cupla/kernel.hpp
@@ -145,7 +145,7 @@ namespace traits
         template<
             typename... TArgs
         >
-        ALPAKA_FN_HOST
+        ALPAKA_FN_HOST_ACC
         static auto
         getBlockSharedMemDynSizeBytes(
             ::cupla::CuplaKernel< T_UserKernel > const & userKernel,


### PR DESCRIPTION
Alpaka is defining `getBlockSharedMemDynSizeBytes` as `ALPAKA_FN_HOST_ACC`.
Cupla is providing a declaration for cupla kernels with the suffix `ALPAKA_FN_HOST`.
Together with the HIP backend this inconsitancy will results into compile errors.

- fix function suffix