### PR TITLE
update to latest alpaka develop

### DIFF
--- a/include/cupla/kernel.hpp
+++ b/include/cupla/kernel.hpp
@@ -119,7 +119,7 @@ namespace cupla{
             static_cast<IdxVec3>(blockSize),
             static_cast<IdxVec3>(elemPerThread)
         );
-        auto const exec(::alpaka::kernel::createTaskExec<T_Acc>(workDiv, kernel, args...));
+        auto const exec(::alpaka::kernel::createTaskKernel<T_Acc>(workDiv, kernel, args...));
         ::alpaka::queue::enqueue(stream, exec);
     }
 


### PR DESCRIPTION
- update alpaka to c922a19c2acfd743e1251680dc2b87863ee1549b
- dependency changes: rename `createTaskExec` -> `createTaskKernel` cherry picked from #101