### PR TITLE
Mark the TBB backend as "thread sequential"

### DIFF
--- a/include/cupla/traits/IsThreadSeqAcc.hpp
+++ b/include/cupla/traits/IsThreadSeqAcc.hpp
@@ -72,5 +72,21 @@ namespace traits
     };
 #endif
 
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+    template<
+        typename T_KernelDim,
+        typename T_IndexType
+    >
+    struct IsThreadSeqAcc<
+        ::alpaka::acc::AccCpuTbbBlocks<
+            T_KernelDim,
+            T_IndexType
+        >
+    >
+    {
+        static constexpr bool value = true;
+    };
+#endif
+
 }  // namespace traits
 } // namespace cupla


### PR DESCRIPTION
This lets `CUPLA_KERNEL_OPTI` swap the threads and elements when using the TBB backend, as it does for the serial and OpenMP ones.