### PR TITLE
Move all accelerator-specific code to an inline namespace

### DIFF
--- a/include/cuda_to_cupla.hpp
+++ b/include/cuda_to_cupla.hpp
@@ -21,7 +21,6 @@
 
 #pragma once
 
-
 #include "cupla_runtime.hpp"
 
 #include "cupla/cudaToCupla/driverTypes.hpp"

--- a/include/cupla/api/common.hpp
+++ b/include/cupla/api/common.hpp
@@ -23,9 +23,12 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla_driver_types.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 const char *
 cuplaGetErrorString(cuplaError_t);
@@ -51,3 +54,5 @@ cuplaGetLastError();
  */
 cuplaError_t
 cuplaPeekAtLastError();
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/include/cupla/api/device.hpp
+++ b/include/cupla/api/device.hpp
@@ -23,14 +23,15 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla_driver_types.hpp"
 
-
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 cuplaError_t
 cuplaGetDeviceCount( int * count);
-
 
 cuplaError_t
 cuplaSetDevice( int idx);
@@ -49,3 +50,5 @@ cuplaMemGetInfo(
     size_t * free,
     size_t * total
 );
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/include/cupla/api/event.hpp
+++ b/include/cupla/api/event.hpp
@@ -23,8 +23,12 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla_driver_types.hpp"
+
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 cuplaError_t
 cuplaEventCreateWithFlags(
@@ -60,3 +64,5 @@ cuplaEventSynchronize(
 
 cuplaError_t
 cuplaEventQuery( cuplaEvent_t event );
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/include/cupla/api/memory.hpp
+++ b/include/cupla/api/memory.hpp
@@ -23,15 +23,17 @@
 
 #include <alpaka/alpaka.hpp>
 
-
 #include "cupla/datatypes/dim3.hpp"
 #include "cupla/datatypes/uint.hpp"
 #include "cupla/c/datatypes/cuplaExtent.hpp"
 #include "cupla/c/datatypes/cuplaPitchedPtr.hpp"
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla_driver_types.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 cuplaError_t
 cuplaMalloc(
@@ -154,3 +156,5 @@ cuplaError_t
 cuplaMemcpy3D(
     const cuplaMemcpy3DParms * const p
 );
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/include/cupla/api/stream.hpp
+++ b/include/cupla/api/stream.hpp
@@ -23,9 +23,12 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla_driver_types.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 cuplaError_t
 cuplaStreamCreate(
@@ -49,3 +52,5 @@ cuplaStreamWaitEvent(
 
 cuplaError_t
 cuplaStreamQuery( cuplaStream_t stream );
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/include/cupla/c/datatypes/cuplaArray.hpp
+++ b/include/cupla/c/datatypes/cuplaArray.hpp
@@ -21,12 +21,17 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla/c/datatypes/cuplaPitchedPtr.hpp"
 #include "cupla/c/datatypes/cuplaPos.hpp"
 #include "cupla/c/datatypes/cuplaExtent.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 struct cuplaArray
 {
 };
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/include/cupla/c/datatypes/cuplaExtent.hpp
+++ b/include/cupla/c/datatypes/cuplaExtent.hpp
@@ -21,7 +21,11 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
+
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 struct cuplaExtent{
     cupla::MemSizeType width, height, depth;
@@ -74,6 +78,7 @@ struct cuplaExtent{
     }
 };
 
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 
 
 namespace alpaka

--- a/include/cupla/c/datatypes/cuplaMemcpy3DParms.hpp
+++ b/include/cupla/c/datatypes/cuplaMemcpy3DParms.hpp
@@ -21,12 +21,15 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla/c/datatypes/cuplaArray.hpp"
 #include "cupla/c/datatypes/cuplaPitchedPtr.hpp"
 #include "cupla/c/datatypes/cuplaPos.hpp"
 #include "cupla/c/datatypes/cuplaExtent.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 struct cuplaMemcpy3DParms
 {
@@ -41,3 +44,5 @@ struct cuplaMemcpy3DParms
 
     cuplaMemcpy3DParms() = default;
 };
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/include/cupla/c/datatypes/cuplaPitchedPtr.hpp
+++ b/include/cupla/c/datatypes/cuplaPitchedPtr.hpp
@@ -21,9 +21,12 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla/datatypes/uint.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 struct cuplaPitchedPtr
 {
@@ -46,3 +49,5 @@ struct cuplaPitchedPtr
     {}
 
 };
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/include/cupla/c/datatypes/cuplaPos.hpp
+++ b/include/cupla/c/datatypes/cuplaPos.hpp
@@ -21,7 +21,11 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
+
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 struct cuplaPos{
     size_t x, y, z;
@@ -74,7 +78,7 @@ struct cuplaPos{
     }
 };
 
-
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 
 namespace alpaka
 {

--- a/include/cupla/cudaToCupla/driverTypes.hpp
+++ b/include/cupla/cudaToCupla/driverTypes.hpp
@@ -108,7 +108,10 @@
 #define uint3 ::cupla::uint3
 
 // recast functions
-namespace cupla {
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
     template< typename A, typename B >
     ALPAKA_FN_HOST_ACC
@@ -118,7 +121,9 @@ namespace cupla {
         return reinterpret_cast< B const & >( x );
     }
 
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
 } // namespace cupla
+
 #ifndef ALPAKA_ACC_GPU_CUDA_ENABLED
 #   define __int_as_float(...) cupla::A_as_B< int, float >( __VA_ARGS__ )
 #   define __float_as_int(...) cupla::A_as_B< float, int >( __VA_ARGS__ )

--- a/include/cupla/datatypes/Array.hpp
+++ b/include/cupla/datatypes/Array.hpp
@@ -21,9 +21,13 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 
-namespace cupla{
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
     template<
         typename T_Type,
@@ -55,4 +59,5 @@ namespace cupla{
         }
     };
 
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 } //namespace cupla

--- a/include/cupla/datatypes/dim3.hpp
+++ b/include/cupla/datatypes/dim3.hpp
@@ -21,10 +21,13 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla/datatypes/uint.hpp"
 
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 
     struct dim3
@@ -62,4 +65,5 @@ namespace cupla
         }
     };
 
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 } //namespace cupla

--- a/include/cupla/datatypes/uint.hpp
+++ b/include/cupla/datatypes/uint.hpp
@@ -21,9 +21,12 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 
     struct uint3{
@@ -76,7 +79,8 @@ namespace cupla
         }
     };
 
-} //namespace cupla
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namespace cupla
 
 
 namespace alpaka

--- a/include/cupla/defines.hpp
+++ b/include/cupla/defines.hpp
@@ -1,0 +1,102 @@
+/* Copyright 2016 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <alpaka/alpaka.hpp>
+#include <cstdint>
+
+#include "cupla/namespace.hpp"
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#   undef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#   define ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#   undef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#   define ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#   undef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#   define ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#   undef ALPAKA_ACC_GPU_CUDA_ENABLED
+#   define ALPAKA_ACC_GPU_CUDA_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#   undef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#   define ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#   undef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#   define ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED 1
+#endif
+
+#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
+#   undef ALPAKA_ACC_GPU_HIP_ENABLED
+#   define ALPAKA_ACC_GPU_HIP_ENABLED 1
+#endif
+
+#define CUPLA_NUM_SELECTED_DEVICES (                                           \
+        ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED +                                  \
+        ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED +                               \
+        ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED  +                                 \
+        ALPAKA_ACC_GPU_CUDA_ENABLED +                                          \
+        ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED +                                   \
+        ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED +                                   \
+        ALPAKA_ACC_GPU_HIP_ENABLED                                             \
+)
+
+
+#if( CUPLA_NUM_SELECTED_DEVICES == 0 )
+    #error "there is no accelerator selected, please run `ccmake .` and select one"
+#endif
+
+#if( CUPLA_NUM_SELECTED_DEVICES > 2  )
+    #error "please select at most two accelerators"
+#endif
+
+// count accelerators where the thread count must be one
+#define CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES (                                \
+        ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED +                                  \
+        ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED +                                   \
+        ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED                                     \
+)
+
+#define CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES (                           \
+        ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED +                                  \
+        ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED +                               \
+        ALPAKA_ACC_GPU_CUDA_ENABLED +                                          \
+        ALPAKA_ACC_GPU_HIP_ENABLED                                             \
+)
+
+#if( CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES > 1 )
+    #error "it is only alowed to select one thread sequential Alpaka accelerator"
+#endif
+
+#if( CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES > 1 )
+    #error "it is only alowed to select one thread parallelized Alpaka accelerator"
+#endif

--- a/include/cupla/kernel.hpp
+++ b/include/cupla/kernel.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 
 #include "cupla/datatypes/dim3.hpp"
@@ -31,8 +32,10 @@
 
 #include <utility>
 
-
-namespace cupla{
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
     /** get block and elements extents
      *
@@ -123,6 +126,7 @@ namespace cupla{
         ::alpaka::queue::enqueue(stream, exec);
     }
 
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
 } // namespace cupla
 
 

--- a/include/cupla/manager/Device.hpp
+++ b/include/cupla/manager/Device.hpp
@@ -21,14 +21,18 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla_driver_types.hpp"
+
 #include <map>
 #include <memory>
 #include <sstream>
 #include <stdexcept>
 
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 namespace manager
 {
@@ -171,4 +175,5 @@ namespace manager
     };
 
 } //namespace manager
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 } //namespace cupla

--- a/include/cupla/manager/Driver.hpp
+++ b/include/cupla/manager/Driver.hpp
@@ -21,7 +21,11 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
+
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 namespace manager
 {
@@ -45,4 +49,5 @@ private:
 };
 
 } //namespace manager
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 } //namespace cupla

--- a/include/cupla/manager/Event.hpp
+++ b/include/cupla/manager/Event.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla/manager/Device.hpp"
 #include "cupla_driver_types.hpp"
@@ -32,6 +33,8 @@
 #include <chrono>
 
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 namespace manager
 {
@@ -236,4 +239,5 @@ namespace detail
     };
 
 } //namespace manager
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 } //namespace cupla

--- a/include/cupla/manager/Memory.hpp
+++ b/include/cupla/manager/Memory.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla/manager/Device.hpp"
 
@@ -30,6 +31,8 @@
 #include <utility>
 
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 namespace manager
 {
@@ -148,4 +151,5 @@ namespace manager
     };
 
 } //namespace manager
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 } //namespace cupla

--- a/include/cupla/manager/Stream.hpp
+++ b/include/cupla/manager/Stream.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla/manager/Device.hpp"
 #include "cupla_driver_types.hpp"
@@ -30,6 +31,8 @@
 #include <memory>
 
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 namespace manager
 {
@@ -168,4 +171,5 @@ namespace manager
     };
 
 } //namespace manager
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 } //namespace cupla

--- a/include/cupla/namespace.hpp
+++ b/include/cupla/namespace.hpp
@@ -1,4 +1,4 @@
-/* Copyright 2019 Andrea Bocci
+/* Copyright 2019 Andrea Bocci, Rene Widera
  *
  * This file is part of cupla.
  *
@@ -18,60 +18,76 @@
  *
  */
 
-
 #pragma once
+
+#include "cupla/defines.hpp"
+
 
 #if CUPLA_STREAM_ASYNC_ENABLED
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_async
-#endif
+// thread parallel and thread sequential accelerator is used together
+#   if(CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES == 1 && CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES == 1)
+#       define CUPLA_ACCELERATOR_NAMESPACE cupla_mixed_async
+#   else
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_async
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_async
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_async
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_async
+#       endif
 
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_async
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_async
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_async
-#endif
+#       ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_async
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_async
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_async
+#       endif
+
+#       ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_async
+#       endif
+
+#   endif // mixed accelerator usage
 
 #else // CUPLA_STREAM_ASYNC_ENABLED
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_sync
-#endif
+// thread parallel and thread sequential accelerator is used together
+#   if(CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES == 1 && CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES == 1)
+#       define CUPLA_ACCELERATOR_NAMESPACE cupla_mixed_sync
+#   else
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_sync
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_sync
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_sync
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_sync
+#       endif
 
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_sync
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_sync
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_sync
-#endif
+#       ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_sync
+#       endif
 
-#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-#define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_sync
-#endif
+#       ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_sync
+#       endif
+
+#       ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#           define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_sync
+#       endif
+
+#   endif // mixed accelerator usage
 
 #endif // CUPLA_STREAM_ASYNC_ENABLED
 

--- a/include/cupla/namespace.hpp
+++ b/include/cupla/namespace.hpp
@@ -1,0 +1,82 @@
+/* Copyright 2019 Andrea Bocci
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#if CUPLA_STREAM_ASYNC_ENABLED
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_async
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_async
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_async
+#endif
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_async
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_async
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_async
+#endif
+
+#else // CUPLA_STREAM_ASYNC_ENABLED
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_omp2_sync
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_threads_sync
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_omp2_seq_sync
+#endif
+
+#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_cuda_sync
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_seq_seq_sync
+#endif
+
+#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
+#define CUPLA_ACCELERATOR_NAMESPACE cupla_tbb_seq_sync
+#endif
+
+#endif // CUPLA_STREAM_ASYNC_ENABLED
+
+/*
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
+*/

--- a/include/cupla/traits/IsThreadSeqAcc.hpp
+++ b/include/cupla/traits/IsThreadSeqAcc.hpp
@@ -21,9 +21,12 @@
 
 #pragma once
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 namespace traits
 {
@@ -88,5 +91,6 @@ namespace traits
     };
 #endif
 
-}  // namespace traits
+} // namespace traits
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
 } // namespace cupla

--- a/include/cupla/types.hpp
+++ b/include/cupla/types.hpp
@@ -18,89 +18,13 @@
  *
  */
 
-
 #pragma once
 
 #include <alpaka/alpaka.hpp>
 #include <cstdint>
 
+#include "cupla/defines.hpp"
 #include "cupla/namespace.hpp"
-
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
-#   undef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
-#   define ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED 1
-#endif
-
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
-#   undef ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED
-#   define ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED 1
-#endif
-
-#ifdef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-#   undef ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED
-#   define ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED 1
-#endif
-
-#ifdef ALPAKA_ACC_GPU_CUDA_ENABLED
-#   undef ALPAKA_ACC_GPU_CUDA_ENABLED
-#   define ALPAKA_ACC_GPU_CUDA_ENABLED 1
-#endif
-
-#ifdef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-#   undef ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED
-#   define ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED 1
-#endif
-
-#ifdef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-#   undef ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED
-#   define ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED 1
-#endif
-
-#ifdef ALPAKA_ACC_GPU_HIP_ENABLED
-#   undef ALPAKA_ACC_GPU_HIP_ENABLED
-#   define ALPAKA_ACC_GPU_HIP_ENABLED 1
-#endif
-
-#define CUPLA_NUM_SELECTED_DEVICES (                                           \
-        ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED +                                  \
-        ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED +                               \
-        ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED  +                                 \
-        ALPAKA_ACC_GPU_CUDA_ENABLED +                                          \
-        ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED +                                   \
-        ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED +                                   \
-        ALPAKA_ACC_GPU_HIP_ENABLED                                             \
-)
-
-
-#if( CUPLA_NUM_SELECTED_DEVICES == 0 )
-    #error "there is no accelerator selected, please run `ccmake .` and select one"
-#endif
-
-#if( CUPLA_NUM_SELECTED_DEVICES > 2  )
-    #error "please select at most two accelerators"
-#endif
-
-// count accelerators where the thread count must be one
-#define CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES (                                \
-        ALPAKA_ACC_CPU_B_OMP2_T_SEQ_ENABLED +                                  \
-        ALPAKA_ACC_CPU_B_SEQ_T_SEQ_ENABLED +                                   \
-        ALPAKA_ACC_CPU_B_TBB_T_SEQ_ENABLED                                     \
-)
-
-#define CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES (                           \
-        ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED +                                  \
-        ALPAKA_ACC_CPU_B_SEQ_T_THREADS_ENABLED +                               \
-        ALPAKA_ACC_GPU_CUDA_ENABLED +                                          \
-        ALPAKA_ACC_GPU_HIP_ENABLED                                             \
-)
-
-#if( CUPLA_NUM_SELECTED_THREAD_SEQ_DEVICES > 1 )
-    #error "it is only alowed to select one thread sequential Alpaka accelerator"
-#endif
-
-#if( CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES > 1 )
-    #error "it is only alowed to select one thread parallelized Alpaka accelerator"
-#endif
 
 namespace cupla
 {

--- a/include/cupla/types.hpp
+++ b/include/cupla/types.hpp
@@ -24,6 +24,8 @@
 #include <alpaka/alpaka.hpp>
 #include <cstdint>
 
+#include "cupla/namespace.hpp"
+
 #ifdef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
 #   undef ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED
 #   define ALPAKA_ACC_CPU_B_SEQ_T_OMP2_ENABLED 1
@@ -100,9 +102,10 @@
     #error "it is only alowed to select one thread parallelized Alpaka accelerator"
 #endif
 
-
-namespace cupla {
-
+namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
     using MemSizeType = size_t;
     using IdxType = unsigned int;
@@ -302,5 +305,6 @@ namespace cupla {
             AlpakaDim< T_dim >,
             MemSizeType
         >;
-} // namepsace cupla
 
+} // namespace CUPLA_ACCELERATOR_NAMESPACE
+} // namepsace cupla

--- a/include/cupla_runtime.hpp
+++ b/include/cupla_runtime.hpp
@@ -23,6 +23,7 @@
 
 #include <alpaka/alpaka.hpp>
 
+#include "cupla/namespace.hpp"
 #include "cupla/kernel.hpp"
 
 #include "cupla/c/datatypes/cuplaArray.hpp"
@@ -45,5 +46,9 @@
 
 namespace cupla
 {
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
     const auto driver = manager::Driver::get();
-}
+
+} //namespace cupla
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -19,6 +19,7 @@
  */
 
 
+#include "cupla/namespace.hpp"
 #include "cupla_runtime.hpp"
 #include "cupla/manager/Memory.hpp"
 #include "cupla/manager/Device.hpp"
@@ -26,6 +27,8 @@
 #include "cupla/manager/Event.hpp"
 #include "cupla/api/common.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 const char *
 cuplaGetErrorString(cuplaError_t e)
@@ -57,3 +60,5 @@ cuplaPeekAtLastError()
     return cuplaSuccess;
 #endif
 }
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -19,6 +19,7 @@
  */
 
 
+#include "cupla/namespace.hpp"
 #include "cupla_runtime.hpp"
 #include "cupla/manager/Memory.hpp"
 #include "cupla/manager/Device.hpp"
@@ -26,6 +27,9 @@
 #include "cupla/manager/Event.hpp"
 #include "cupla/api/device.hpp"
 #include <stdexcept>
+
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 cuplaError_t
 cuplaGetDeviceCount( int * count)
@@ -117,3 +121,5 @@ cuplaMemGetInfo(
     *free = ::alpaka::dev::getFreeMemBytes( device );
     return cuplaSuccess;
 }
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -19,6 +19,7 @@
  */
 
 
+#include "cupla/namespace.hpp"
 #include "cupla_runtime.hpp"
 #include "cupla/manager/Memory.hpp"
 #include "cupla/manager/Device.hpp"
@@ -26,6 +27,8 @@
 #include "cupla/manager/Event.hpp"
 #include "cupla/api/event.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 cuplaError_t
 cuplaEventCreateWithFlags(
@@ -136,3 +139,5 @@ cuplaEventQuery( cuplaEvent_t event )
         return cuplaErrorNotReady;
     }
 }
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/src/manager/Driver.cpp
+++ b/src/manager/Driver.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "cupla/namespace.hpp"
 #include "cupla/types.hpp"
 #include "cupla_runtime.hpp"
 #include "cupla/manager/Driver.hpp"
@@ -27,6 +28,8 @@
 #include "cupla/manager/Event.hpp"
 
 namespace cupla
+{
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 namespace manager
 {
@@ -63,4 +66,5 @@ Driver::Driver()
 
 
 } //namespace manager
+} //namespace CUPLA_ACCELERATOR_NAMESPACE
 } //namespace cupla

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -19,6 +19,7 @@
  */
 
 
+#include "cupla/namespace.hpp"
 #include "cupla_runtime.hpp"
 #include "cupla/manager/Memory.hpp"
 #include "cupla/manager/Device.hpp"
@@ -26,6 +27,8 @@
 #include "cupla/manager/Event.hpp"
 #include "cupla/api/memory.hpp"
 
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 cuplaError_t
 cuplaMalloc(
@@ -948,3 +951,5 @@ cuplaMemcpy3D(
 
     return cuplaSuccess;
 }
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -19,6 +19,7 @@
  */
 
 
+#include "cupla/namespace.hpp"
 #include "cupla_runtime.hpp"
 #include "cupla/manager/Memory.hpp"
 #include "cupla/manager/Device.hpp"
@@ -26,6 +27,9 @@
 #include "cupla/manager/Event.hpp"
 
 #include "cupla/api/stream.hpp"
+
+inline namespace CUPLA_ACCELERATOR_NAMESPACE
+{
 
 
 cuplaError_t
@@ -101,3 +105,5 @@ cuplaStreamQuery( cuplaStream_t stream )
     else
         return cuplaErrorNotReady;
 };
+
+} //namespace CUPLA_ACCELERATOR_NAMESPACE


### PR DESCRIPTION
The encapsulation results in different symbols for different accelerators, and allows linking modules compiled for different Cupla backends in a single binary.

Using inline namespaces leaves the rest of cupla and the user's code unchanged.

Keeping the accelerator-specific namespace inside the cupla namespace (where it is used) leaves the latter unambiguous, and allowing references to `namespace cupla`and qualified symbols like `::cupla:...` unchanged.