### PR TITLE
Changes function to macro 'CUPLA_ADD_EXECUTABLE'.

### DIFF
--- a/cmake/addExecutable.cmake
+++ b/cmake/addExecutable.cmake
@@ -22,7 +22,7 @@
 cmake_minimum_required(VERSION 3.3.0)
 
 
-function(CUPLA_ADD_EXECUTABLE BinaryName)
+macro(CUPLA_ADD_EXECUTABLE BinaryName)
 
     include_directories(${cupla_INCLUDE_DIRS})
     add_definitions(${cupla_DEFINITIONS})
@@ -32,4 +32,4 @@ function(CUPLA_ADD_EXECUTABLE BinaryName)
         ${ARGN}
         ${cupla_SOURCE_FILES}
     )
-endfunction()
+endmacro()


### PR DESCRIPTION
- it removes the unnecessary scope of the function for `CUPLA_ADD_EXECUTABLE`
- especially needed for HIP

Edit: ... otherwise linking with HIP will fail due to a messed up cmake command