### PR TITLE
configuration header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ before_install:
   - mkdir -p $HOME/asyncAPI
   - mkdir -p $HOME/asyncAPI_tuned
   - mkdir -p $HOME/vectorAdd
+  - mkdir -p $HOME/test/config
   - export CMAKE_FLAGS="-DALPAKA_ACC_"$STRATEGY"_ENABLE=ON"
   - if [ "$COMPILER" == "gcc" ]; then
         echo "Using g++-4.9 and sequential OpenMP2 threads ...";
@@ -155,5 +156,9 @@ script:
       ./vectorAdd 100000;
     fi
   #############################################################################
-  # Test: (To do: add tests in $TRAVIS_BUILD_DIR/test/                        #
+  # Test: additional tests                                                    #
   #############################################################################
+  - cd $HOME/test/config
+  - if [[ $CXX =~ "^g\+\+" ]] || [[ "$COMPILER" == "nvcc" ]] ; then
+      $TRAVIS_BUILD_DIR/test/system/config/test.sh $CXX;
+    fi

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage
 - Checkout the [tuning guide](doc/TuningGuide.md) for a step further to performance
   portable code.
 
+[cupla can be used as a header-only library and without the CMake build system](doc/ConfigurationHeader.md)
 
 Authors
 -------

--- a/doc/ConfigurationHeader.md
+++ b/doc/ConfigurationHeader.md
@@ -1,0 +1,46 @@
+Configuration Header for *cupla*
+=============================
+
+cupla provides configuration header to use the library without CMake, e.g in a [cling](https://github.com/root-project/cling) environment.
+
+
+Available Pre-compiler Definitions 
+=================================
+
+Pre-compiler definitions can be used to control the behavior of cupla/alpaka.
+The definitions must be passed via a compiler flag or be defined before the accelerator header is included.
+The default value will be used if the configuration header is included without defining any of the following options.
+
+- `CUPLA_STREAM_ASYNC_ENABLED`: `0` use synchronous streams (default), `1` use asynchronous streams
+- `CUPLA_HEADER_ONLY`: `1` *cupla* will be used as header-only library (default), otherwise you must compile all `.cpp` files in [`src/`](https://github.com/ComputationalRadiationPhysics/cupla/tree/master/src)
+
+
+linker dependencies
+===================
+
+Depending of the used accelerator you must link the library `pthread` and/or activate OpenMP support.
+
+
+Example
+=======
+
+To select an accelerator you must include the corresponding accelerator header from [`cupla/config/`](https://github.com/ComputationalRadiationPhysics/cupla/tree/master/include/cupla/config)
+
+
+```C++
+
+// use synchronous streams for the accelerator
+#define CUPLA_STREAM_ASYNC_ENABLED 0
+// use cupla as header-only library
+#define CUPLA_HEADER_ONLY 1
+#include <cupla/config/CpuSerial.hpp>
+
+
+int main()
+{
+    int* res_ptr_d = nullptr;
+    cudaMalloc( (void**)&res_ptr_d, sizeof( int ) );
+
+    return 0;
+}
+```

--- a/include/cupla/config/CpuOmp2Blocks.hpp
+++ b/include/cupla/config/CpuOmp2Blocks.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include <alpaka/standalone/CpuOmp2Blocks.hpp>
+
+#ifndef CUPLA_HEADER_ONLY
+#   define CUPLA_HEADER_ONLY 1
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC inline
+#endif
+#include "cuda_to_cupla.hpp"
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   include "cupla/../../src/manager/Driver.cpp"
+#   include "cupla/../../src/common.cpp"
+#   include "cupla/../../src/device.cpp"
+#   include "cupla/../../src/event.cpp"
+#   include "cupla/../../src/memory.cpp"
+#   include "cupla/../../src/stream.cpp"
+#endif

--- a/include/cupla/config/CpuOmp2Threads.hpp
+++ b/include/cupla/config/CpuOmp2Threads.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include <alpaka/standalone/CpuOmp2Threads.hpp>
+
+#ifndef CUPLA_HEADER_ONLY
+#   define CUPLA_HEADER_ONLY 1
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC inline
+#endif
+#include "cuda_to_cupla.hpp"
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   include "cupla/../../src/manager/Driver.cpp"
+#   include "cupla/../../src/common.cpp"
+#   include "cupla/../../src/device.cpp"
+#   include "cupla/../../src/event.cpp"
+#   include "cupla/../../src/memory.cpp"
+#   include "cupla/../../src/stream.cpp"
+#endif

--- a/include/cupla/config/CpuSerial.hpp
+++ b/include/cupla/config/CpuSerial.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include <alpaka/standalone/CpuSerial.hpp>
+
+#ifndef CUPLA_HEADER_ONLY
+#   define CUPLA_HEADER_ONLY 1
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC inline
+#endif
+#include "cuda_to_cupla.hpp"
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   include "cupla/../../src/manager/Driver.cpp"
+#   include "cupla/../../src/common.cpp"
+#   include "cupla/../../src/device.cpp"
+#   include "cupla/../../src/event.cpp"
+#   include "cupla/../../src/memory.cpp"
+#   include "cupla/../../src/stream.cpp"
+#endif

--- a/include/cupla/config/CpuTbbBlocks.hpp
+++ b/include/cupla/config/CpuTbbBlocks.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include <alpaka/standalone/CpuTbbBlocks.hpp>
+
+#ifndef CUPLA_HEADER_ONLY
+#   define CUPLA_HEADER_ONLY 1
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC inline
+#endif
+#include "cuda_to_cupla.hpp"
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   include "cupla/../../src/manager/Driver.cpp"
+#   include "cupla/../../src/common.cpp"
+#   include "cupla/../../src/device.cpp"
+#   include "cupla/../../src/event.cpp"
+#   include "cupla/../../src/memory.cpp"
+#   include "cupla/../../src/stream.cpp"
+#endif

--- a/include/cupla/config/CpuThreads.hpp
+++ b/include/cupla/config/CpuThreads.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include <alpaka/standalone/CpuThreads.hpp>
+
+#ifndef CUPLA_HEADER_ONLY
+#   define CUPLA_HEADER_ONLY 1
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC inline
+#endif
+#include "cuda_to_cupla.hpp"
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   include "cupla/../../src/manager/Driver.cpp"
+#   include "cupla/../../src/common.cpp"
+#   include "cupla/../../src/device.cpp"
+#   include "cupla/../../src/event.cpp"
+#   include "cupla/../../src/memory.cpp"
+#   include "cupla/../../src/stream.cpp"
+#endif

--- a/include/cupla/config/GpuCudaRt.hpp
+++ b/include/cupla/config/GpuCudaRt.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include <alpaka/standalone/GpuCudaRt.hpp>
+
+#ifndef CUPLA_HEADER_ONLY
+#   define CUPLA_HEADER_ONLY 1
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC inline
+#endif
+#include "cuda_to_cupla.hpp"
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   include "cupla/../../src/manager/Driver.cpp"
+#   include "cupla/../../src/common.cpp"
+#   include "cupla/../../src/device.cpp"
+#   include "cupla/../../src/event.cpp"
+#   include "cupla/../../src/memory.cpp"
+#   include "cupla/../../src/stream.cpp"
+#endif

--- a/include/cupla/config/GpuHipRt.hpp
+++ b/include/cupla/config/GpuHipRt.hpp
@@ -1,0 +1,42 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#pragma once
+
+#include <alpaka/standalone/GpuHipRt.hpp>
+
+#ifndef CUPLA_HEADER_ONLY
+#   define CUPLA_HEADER_ONLY 1
+#endif
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC inline
+#endif
+#include "cuda_to_cupla.hpp"
+
+#if( CUPLA_HEADER_ONLY == 1 )
+#   include "cupla/../../src/manager/Driver.cpp"
+#   include "cupla/../../src/common.cpp"
+#   include "cupla/../../src/device.cpp"
+#   include "cupla/../../src/event.cpp"
+#   include "cupla/../../src/memory.cpp"
+#   include "cupla/../../src/stream.cpp"
+#endif

--- a/include/cupla/defines.hpp
+++ b/include/cupla/defines.hpp
@@ -100,3 +100,7 @@
 #if( CUPLA_NUM_SELECTED_THREAD_PARALLEL_DEVICES > 1 )
     #error "it is only alowed to select one thread parallelized Alpaka accelerator"
 #endif
+
+#ifndef CUPLA_HEADER_ONLY_FUNC_SPEC
+#   define CUPLA_HEADER_ONLY_FUNC_SPEC
+#endif

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -30,18 +30,21 @@
 inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 const char *
 cuplaGetErrorName(cuplaError_t e)
 {
     return CuplaErrorCode::message_cstr(e);
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 const char *
 cuplaGetErrorString(cuplaError_t e)
 {
     return CuplaErrorCode::message_cstr(e);
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaGetLastError()
 {
@@ -55,6 +58,7 @@ cuplaGetLastError()
 #endif
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaPeekAtLastError()
 {

--- a/src/device.cpp
+++ b/src/device.cpp
@@ -31,6 +31,7 @@
 inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaGetDeviceCount( int * count)
 {
@@ -38,6 +39,7 @@ cuplaGetDeviceCount( int * count)
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaSetDevice( int idx)
 {
@@ -52,6 +54,7 @@ cuplaSetDevice( int idx)
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaGetDevice( int * deviceId )
 {
@@ -59,6 +62,7 @@ cuplaGetDevice( int * deviceId )
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaDeviceReset( )
 {
@@ -97,6 +101,7 @@ cuplaDeviceReset( )
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaDeviceSynchronize( )
 {
@@ -106,6 +111,7 @@ cuplaDeviceSynchronize( )
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMemGetInfo(
     size_t * free,

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -30,6 +30,7 @@
 inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaEventCreateWithFlags(
     cuplaEvent_t * event,
@@ -44,6 +45,8 @@ cuplaEventCreateWithFlags(
     return cuplaSuccess;
 };
 
+
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaEventCreate(
     cuplaEvent_t * event
@@ -57,6 +60,7 @@ cuplaEventCreate(
     return cuplaSuccess;
 };
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaEventDestroy( cuplaEvent_t event )
 {
@@ -71,6 +75,7 @@ cuplaEventDestroy( cuplaEvent_t event )
         return cuplaErrorInitializationError;
 };
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaEventRecord(
     cuplaEvent_t event,
@@ -90,6 +95,7 @@ cuplaEventRecord(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaEventElapsedTime(
     float * ms,
@@ -109,6 +115,7 @@ cuplaEventElapsedTime(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaEventSynchronize(
     cuplaEvent_t event
@@ -122,6 +129,7 @@ cuplaEventSynchronize(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaEventQuery( cuplaEvent_t event )
 {

--- a/src/manager/Driver.cpp
+++ b/src/manager/Driver.cpp
@@ -34,7 +34,7 @@ inline namespace CUPLA_ACCELERATOR_NAMESPACE
 namespace manager
 {
 
-Driver::Driver()
+CUPLA_HEADER_ONLY_FUNC_SPEC Driver::Driver()
 {
     cupla::manager::Device< cupla::AccDev >::get( );
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -30,6 +30,7 @@
 inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMalloc(
     void **ptrptr,
@@ -52,6 +53,7 @@ cuplaMalloc(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMallocPitch(
     void ** devPtr,
@@ -77,6 +79,7 @@ cuplaMallocPitch(
     return cuplaSuccess;
 };
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMalloc3D(
     cuplaPitchedPtr * const pitchedDevPtr,
@@ -100,6 +103,7 @@ cuplaMalloc3D(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaExtent
 make_cuplaExtent(
     size_t const w,
@@ -110,6 +114,7 @@ make_cuplaExtent(
     return cuplaExtent( w, h, d );
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaPos
 make_cuplaPos(
     size_t const x,
@@ -120,6 +125,7 @@ make_cuplaPos(
     return cuplaPos( x, y, z );
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaPitchedPtr
 make_cuplaPitchedPtr(
     void * const d,
@@ -131,6 +137,7 @@ make_cuplaPitchedPtr(
     return cuplaPitchedPtr( d, p, xsz, ysz );
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMallocHost(
     void **ptrptr,
@@ -157,6 +164,7 @@ cuplaMallocHost(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t cuplaFree(void *ptr)
 {
 
@@ -186,6 +194,7 @@ cuplaError_t cuplaFree(void *ptr)
 
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t cuplaFreeHost(void *ptr)
 {
 
@@ -201,6 +210,7 @@ cuplaError_t cuplaFreeHost(void *ptr)
 
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t cuplaMemcpyAsync(
     void *dst,
     const void *src,
@@ -359,6 +369,7 @@ cuplaError_t cuplaMemcpyAsync(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMemcpy(
     void *dst,
@@ -388,6 +399,7 @@ cuplaMemcpy(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMemsetAsync(
     void * devPtr,
@@ -432,6 +444,7 @@ cuplaMemsetAsync(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMemset(
     void * devPtr,
@@ -459,6 +472,7 @@ cuplaMemset(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMemcpy2DAsync(
     void * dst,
@@ -639,6 +653,7 @@ cuplaMemcpy2DAsync(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMemcpy2D(
     void * dst,
@@ -674,6 +689,7 @@ cuplaMemcpy2D(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMemcpy3DAsync(
     const cuplaMemcpy3DParms * const p,
@@ -932,6 +948,7 @@ cuplaMemcpy3DAsync(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaMemcpy3D(
     const cuplaMemcpy3DParms * const p

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -31,7 +31,7 @@
 inline namespace CUPLA_ACCELERATOR_NAMESPACE
 {
 
-
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaStreamCreate(
     cuplaStream_t * stream
@@ -45,6 +45,7 @@ cuplaStreamCreate(
     return cuplaSuccess;
 };
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaStreamDestroy( cuplaStream_t stream )
 {
@@ -59,6 +60,7 @@ cuplaStreamDestroy( cuplaStream_t stream )
         return cuplaErrorInitializationError;
 };
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaStreamSynchronize(
     cuplaStream_t stream
@@ -71,6 +73,8 @@ cuplaStreamSynchronize(
     ::alpaka::wait::wait( streamObject );
     return cuplaSuccess;
 }
+
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaStreamWaitEvent(
     cuplaStream_t stream,
@@ -92,6 +96,7 @@ cuplaStreamWaitEvent(
     return cuplaSuccess;
 }
 
+CUPLA_HEADER_ONLY_FUNC_SPEC
 cuplaError_t
 cuplaStreamQuery( cuplaStream_t stream )
 {

--- a/test/system/config/kernel.cpp
+++ b/test/system/config/kernel.cpp
@@ -1,0 +1,55 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#if defined( CUPLA_ACC_CpuOmp2Blocks  )
+#   include <cupla/config/CpuOmp2Blocks.hpp>
+#elif defined( CUPLA_ACC_CpuOmp2Threads  )
+#   include <cupla/config/CpuOmp2Threads.hpp>
+#elif defined( CUPLA_ACC_CpuSerial )
+#   include <cupla/config/CpuSerial.hpp>
+#elif defined( CUPLA_ACC_CpuTbbBlocks  )
+#   include <cupla/config/CpuTbbBlocks.hpp>
+#elif defined( CUPLA_ACC_CpuThreads  )
+#   include <cupla/config/CpuThreads.hpp>
+#elif defined( CUPLA_ACC_GpuCudaRt  )
+#   include <cupla/config/GpuCudaRt.hpp>
+#elif defined( CUPLA_ACC_GpuHipRt  )
+#   include <cupla/config/GpuHipRt.hpp>
+#endif
+
+struct IncrementKernel
+{
+    template<typename T_Acc>
+    ALPAKA_FN_ACC void operator()( T_Acc const & acc, int * ptr) const
+    {
+        for( int i = 0; i < elemDim.x; ++i )
+            atomicAdd(ptr, 1);
+    }
+};
+
+
+void callIncrementKernel(int* pr_d)
+{
+    // increment 42 times
+    CUPLA_KERNEL_OPTI(
+        IncrementKernel
+    )(7, 6)(pr_d);
+}

--- a/test/system/config/main.cpp
+++ b/test/system/config/main.cpp
@@ -1,0 +1,55 @@
+/* Copyright 2019 Rene Widera
+ *
+ * This file is part of cupla.
+ *
+ * cupla is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * cupla is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with cupla.
+ * If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#if defined( CUPLA_ACC_CpuOmp2Blocks  )
+#   include <cupla/config/CpuOmp2Blocks.hpp>
+#elif defined( CUPLA_ACC_CpuOmp2Threads  )
+#   include <cupla/config/CpuOmp2Threads.hpp>
+#elif defined( CUPLA_ACC_CpuSerial )
+#   include <cupla/config/CpuSerial.hpp>
+#elif defined( CUPLA_ACC_CpuTbbBlocks  )
+#   include <cupla/config/CpuTbbBlocks.hpp>
+#elif defined( CUPLA_ACC_CpuThreads  )
+#   include <cupla/config/CpuThreads.hpp>
+#elif defined( CUPLA_ACC_GpuCudaRt  )
+#   include <cupla/config/GpuCudaRt.hpp>
+#elif defined( CUPLA_ACC_GpuHipRt  )
+#   include <cupla/config/GpuHipRt.hpp>
+#endif
+
+extern void callIncrementKernel(int* pr_d);
+
+int main()
+{
+    int res_h = 0;
+    int *res_ptr_d = nullptr;
+    cudaMalloc( (void**)&res_ptr_d, sizeof( int ) );
+
+    // reset result to zero
+    cuplaMemset( res_ptr_d, 0, sizeof( int ) );
+
+    // increment 42 times
+    callIncrementKernel(res_ptr_d);
+
+    cudaMemcpy(&res_h, res_ptr_d, sizeof( int ), cudaMemcpyDeviceToHost);
+
+    return res_h != 42;
+}

--- a/test/system/config/test.sh
+++ b/test/system/config/test.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+# test compile and execution of a cupla program using its header-only variant
+# $1 C++ compiler name
+
+test_code_dir=$(dirname $0)
+
+# compiles the test case for the given accelerator
+# $1 flag if the compiled binary should be executed, 1 == execute binary else do not test binary 
+# $2 compiler name
+# $3 accelerator name (CpuOmp2Blocks, CpuOmp2Threads, CpuSerial, CpuThreads, GpuCudaRt, GpuHipRt)
+# $4 additional compiler flags
+function compile {
+    execute_bin=$1
+    compiler_name=$2
+    acc_name=$3
+    if [ $# -eq 4 ] ; then
+        compiler_flags="$4"
+    fi
+    ret=$(${compiler_name} ${test_code_dir}/main.cpp ${test_code_dir}/kernel.cpp  -I${test_code_dir}/../../../include -I${test_code_dir}/../../../alpaka/include -std=c++11 -DCUPLA_ACC_${acc_name} -DCUPLA_HEADER_ONLY -o ${acc_name} ${compiler_flags} && \
+        { echo 0; } || { echo 1; })
+    if [ $ret -eq 0 ] && [ $execute_bin -eq 1 ] ; then
+        ret=$(./$acc_name && { echo 0; } || { echo 1; })
+    fi
+    if [ $ret -ne 0 ] ; then
+        echo "Config header test failed for accelerator '$acc_name' with compiler flags '$compiler_flags'" >&2
+    fi
+    return $ret
+}
+
+boost_include="-I$BOOST_ROOT/include"
+
+compile 1 "$1" CpuOmp2Blocks "-fopenmp $boost_include"
+compile 1 "$1" CpuOmp2Blocks "-fopenmp -DCUPLA_STREAM_ASYNC_ENABLE=1 $boost_include"
+compile 0 "$1" CpuOmp2Threads "-fopenmp $boost_include"
+compile 0 "$1" CpuOmp2Threads "-fopenmp -DCUPLA_STREAM_ASYNC_ENABLE=1 $boost_include"
+compile 1 "$1" CpuSerial "$boost_include"
+compile 1 "$1" CpuSerial "-lpthread -DCUPLA_STREAM_ASYNC_ENABLE=1 $boost_include"
+compile 0 "$1" CpuThreads "-lpthread $boost_include"
+compile 0 "$1" CpuThreads "-lpthread -DCUPLA_STREAM_ASYNC_ENABLE=1 $boost_include"
+
+nvcc_found=$(which nvcc >/dev/null && { echo 0; } || { echo 1; })
+if [ $nvcc_found -eq 0 ] ; then
+    compile 0 "nvcc -x cu" GpuCudaRt "-DALPAKA_ACC_GPU_CUDA_ENABLE=ON -DALPAKA_ACC_GPU_CUDA_ONLY_MODE=ON $boost_include"
+    compile 0 "nvcc -x cu" GpuCudaRt "-DALPAKA_ACC_GPU_CUDA_ENABLE=ON -DALPAKA_ACC_GPU_CUDA_ONLY_MODE=ON -DCUPLA_STREAM_ASYNC_ENABLE=1 $boost_include"
+else 
+    echo "skip GpuCudaRt: nvcc not found" >&2
+fi
+
+hipcc_found=$(which hipcc >/dev/null && { echo 0; } || { echo 1; })
+if [ $hipcc_found -eq 0 ] ; then
+    rocm_root="/opt/rocm"
+    hip_include="-I${rocm_root} -I${rocm_root}/rocrand/hiprand/include/ -I${rocm_root}/rocrand/include/"
+    compile 1 "hipcc" GpuHipRt "-DALPAKA_ACC_GPU_HIP_ENABLE=ON -DALPAKA_ACC_GPU_HIP_ONLY_MODE=ON $hip_include $boost_include"
+    compile 1 "hipcc" GpuHipRt "-DALPAKA_ACC_GPU_HIP_ENABLE=ON -DALPAKA_ACC_GPU_HIP_ONLY_MODE=ON -lpthread -DCUPLA_STREAM_ASYNC_ENABLE=1 $hip_include $boost_include"
+else 
+    echo "skip GpuHipRt:  hipcc not found" >&2
+fi


### PR DESCRIPTION
This PR substitute #109

- add configuration header
  - add pre-compiler define to use cupla as header only library
- add documentation
- add tests

CC-ing: @fwyzard 