### PR TITLE
update travis CMake to 3.15.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,15 +67,15 @@ install:
   # CMAKE                                                                     #
   #############################################################################
   - export PATH=$CMAKE_ROOT/bin:$PATH
-  - CMAKE_311_FOUND=$(cmake --version | grep " 3\.11\." >/dev/null && { echo 0; } || { echo 1; })
-  - if [ $CMAKE_311_FOUND -ne 0 ]; then
+  - CMAKE_315_FOUND=$(cmake --version | grep " 3\.15\." >/dev/null && { echo 0; } || { echo 1; })
+  - if [ $CMAKE_315_FOUND -ne 0 ]; then
       mkdir -p $CMAKE_ROOT &&
       cd $CMAKE_ROOT &&
       rm -rf $CMAKE_ROOT/* &&
-      travis_retry wget --no-check-certificate http://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.tar.gz &&
-      tar -xzf cmake-3.11.0-Linux-x86_64.tar.gz &&
-      mv cmake-3.11.0-Linux-x86_64/* . &&
-      rm -rf cmake-3.11.0-Linux-x86_64.tar.gz cmake-3.11.0-Linux-x86_64 &&
+      travis_retry wget --no-check-certificate http://cmake.org/files/v3.15/cmake-3.15.4-Linux-x86_64.tar.gz &&
+      tar -xzf cmake-3.15.4-Linux-x86_64.tar.gz &&
+      mv cmake-3.15.4-Linux-x86_64/* . &&
+      rm -rf cmake-3.15.4-Linux-x86_64.tar.gz cmake-3.15.4-Linux-x86_64 &&
       cd -;
     fi
   - cmake --version


### PR DESCRIPTION
update travis cmake version

This update is required for #128 to switch to the latest alpaka dev branch