### PR TITLE
Fix warnings concerning type casting

### DIFF
--- a/include/cupla/manager/Device.hpp
+++ b/include/cupla/manager/Device.hpp
@@ -163,7 +163,7 @@ namespace manager
         -> int
         {
             using Pltf = ::alpaka::pltf::Pltf< DeviceType >;
-            return ::alpaka::pltf::getDevCount< Pltf >( );
+            return static_cast< int >( ::alpaka::pltf::getDevCount< Pltf >( ) );
         }
 
     protected:

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -111,7 +111,7 @@ cuplaEventElapsedTime(
         cupla::AccDev,
         cupla::AccStream
     >::get().event( end );
-    *ms = eventEnd.elapsedSince(eventStart);
+    *ms = static_cast< float >( eventEnd.elapsedSince( eventStart ) );
     return cuplaSuccess;
 }
 


### PR DESCRIPTION
These two are popping when building PIConGPU `dev` branch. (There might be more of this sort.)