### PR TITLE
pin memory allocated with `cuplaMallocHoast`

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -154,10 +154,7 @@ cuplaMallocHost(
         cupla::AlpakaDim<1u>
     >::get().alloc( extent );
 
-#if defined(ALPAKA_ACC_GPU_CUDA_ENABLED)
-    // only implemented if nvcc is used
-    ::alpaka::mem::buf::pin( buf );
-#endif
+    prepareForAsyncCopy( buf );
 
     // @toto catch errors
     *ptrptr = ::alpaka::mem::view::getPtrNative(buf);


### PR DESCRIPTION
Prepare memory allocated with `cuplaMallocHost` to support memory pinning for all accelerator if alpaka is supporting the functionality.