### PR TITLE
fix `KernelWithElementLevel` documentation

### DIFF
--- a/include/cupla/kernel.hpp
+++ b/include/cupla/kernel.hpp
@@ -172,6 +172,10 @@ inline namespace CUPLA_ACCELERATOR_NAMESPACE
     /* Kernel configuration interface with element support
      *
      * The kernel must support the alpaka element layer.
+     *
+     * Swap the blockSize and the elemSize depending on the activated accelerator.
+     * This mean that in some devices the blockSize is set to one ( dim3(1,1,1) )
+     * and the elemSize is set to the user defined blockSize
      */
     template<
         typename T_KernelType
@@ -201,11 +205,8 @@ inline namespace CUPLA_ACCELERATOR_NAMESPACE
     };
 
     /** Kernel configuration interface with element support
-     * The kernel must support the alpaka element level
      *
-     * Swap the blockSize and the elemSize depending on the activated accelerator.
-     * This mean that in some devices the blockSize is set to one ( dim3(1,1,1) )
-     * and the elemSize is set to the user defined blockSize
+     * The kernel must support the alpaka element level
      */
     template<
         typename T_KernelType


### PR DESCRIPTION
Remove section about swapping element and thread layer.

Bug was introduced with #136

thx @sbastrakov for catching the wrong documentation.